### PR TITLE
build: remove dmg builds in ubuntu, package media libs and add macos entitlements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node-bins
 src-build/node-*
 src-tauri/node-*
+src-build/phnode-*
+src-tauri/phnode-*
 src-tauri/tauri-local.conf.json
 phoenix
 

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,6 +40,9 @@
             "deb": {
                 "depends": []
             },
+            "appimage": {
+                "bundleMediaFramework": true
+            },
             "externalBin": [
                 "./phnode"
             ],
@@ -53,8 +56,8 @@
             "identifier": "dev.phcode",
             "longDescription": "Phoenix is a modern open-source IDE for the web, built for the browser",
             "macOS": {
-                "entitlements": null,
-                "exceptionDomain": "",
+                "entitlements": "../entitlements.plist",
+                "exceptionDomain": "localhost",
                 "frameworks": [],
                 "providerShortName": null,
                 "signingIdentity": null
@@ -63,7 +66,7 @@
                 "app/*"
             ],
             "shortDescription": "Phoenix is a modern open-source IDE for the web, built for the browser",
-            "targets": ["deb", "appimage", "nsis", "app", "dmg", "updater"],
+            "targets": ["appimage", "nsis", "app", "dmg", "updater"],
             "windows": {
                 "certificateThumbprint": "AB7D19C00251C1E412594A28DC79D201AAEF50D0",
                 "digestAlgorithm": "sha256",


### PR DESCRIPTION
## Linux Improvements:
In an effort to better support Linux, we have made the decision to distribute the application solely through AppImage. This approach ensures broader compatibility across various Linux distributions and tackles potential dependency issues. Key motivations behind this decision include:

* AppImage updates are supported by Tauri, while DEB updates are currently not.
* At present, Tauri supports only Debian packages, which is not optimal for all Linux distributions.
* AppImage conveniently packages all dependencies, circumventing the classic 'Dependency hell' issue.

To enhance user experience, we will provide an easy mechanism to create shortcuts to the AppImage, enabling our app to be listed conveniently in GNOME/KDE applications folders. We are also considering the implementation of a one-line install script, designed to swiftly download and set up all the required shortcuts on the user's Linux machine.

Furthermore, in order to ensure seamless audio/video playback, we are bundling all media libraries in Tauri by enabling the `bundleMediaFramework` option.

## MacOS Adjustments:
We've also made some changes on the MacOS side:

* An entitlements.plist file has been added.
* For the time being, we've decided not to sandbox our application. This decision was made considering the nature of our IDE - Phoenix code, which requires extensive access to the system. 

Please note, we currently do not have plans for distributing via the App Store due to these extensive system access requirements.

https://github.com/phcode-dev/phoenix-desktop/issues/73

