### PR TITLE
feat: enable dev tools in release builds

### DIFF
--- a/src-build/downloadNode.js
+++ b/src-build/downloadNode.js
@@ -70,8 +70,7 @@ async function downloadNodeBinary(version, platform, arch) {
                     res.pipe(file);
                     res.on('end', () => resolve(fileName));
                     res.on('error', (err) => {
-                        fs.unlink(fileName, () => {
-                        }); // Remove the file on error
+                        fs.unlinkSync(fileName); // Remove the file on error
                         reject(err);
                     });
                 });

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-build = { version = "1.4.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.4.1", features = [ "updater", "shell-sidecar", "fs-all", "window-all"] }
+tauri = { version = "1.4.1", features = [ "updater", "shell-sidecar", "fs-all", "window-all", "devtools"] }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,19 +11,32 @@ fn greet(handle: tauri::AppHandle, name: &str) -> String {
     let resource_path = handle.path_resolver()
         .resolve_resource("app/hello.js")
         .expect("failed to resolve resource");
-    Command::new_sidecar("node")
+    Command::new_sidecar("phnode")
         .expect("failed to create `my-sidecar` binary command")
         .args(resource_path.as_path().to_str())
         .spawn()
         .expect("Failed to spawn sidecar");
-   // let name = "hello";
     println!("hello");
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+#[tauri::command]
+fn toggle_devtools(window: tauri::Window) {
+    static mut DEVTOOLS_LOADED:bool = false;
+    unsafe {
+        // though unsafe, this is fine as its just a view toggle and not mission critical.
+        if !DEVTOOLS_LOADED {
+            window.open_devtools();
+        } else {
+            window.close_devtools();
+        }
+        DEVTOOLS_LOADED = !DEVTOOLS_LOADED;
+    }
+}
+
 fn main() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![greet, toggle_devtools])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
                 "sidecar": true,
                 "scope": [
                     {
-                        "name": "node",
+                        "name": "phnode",
                         "sidecar": true
                     }
                 ]


### PR DESCRIPTION
1. Enable dev tools in release builds
2. Also updated to use unlink sync if node down,load fail during build step
3. Add js custom API to toggle dev tools from window
```js
invoke("toggle_devtools", {});
```
![image](https://github.com/phcode-dev/phoenix-desktop/assets/5336369/0ec6343e-31d3-4c54-9d8d-72ace3b45dfa)

