### PR TITLE
feat: resize window on startup to last known size

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2027,8 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "phoenix-code-ide"
-version = "3.2.3"
+version = "3.2.5"
 dependencies = [
+ "once_cell",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "1.4.0", features = [] }
 
 [dependencies]
 serde_json = "1.0"
+once_cell = "1.18.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.4.1", features = [ "updater", "shell-sidecar", "fs-all", "window-all", "devtools"] }
 

--- a/src-tauri/src/boot_config.rs
+++ b/src-tauri/src/boot_config.rs
@@ -1,0 +1,43 @@
+use serde_json::Value;
+use crate::utilities::read_json_file;
+use std::path::PathBuf;
+
+pub struct BootConfig {
+    pub last_window_width: u32,
+    pub last_window_height: u32,
+}
+static BOOT_CONFIG_FILE_NAME: &'static str = "boot_config.json";
+
+fn get_boot_config_file_path(app_data_dir: &PathBuf) -> PathBuf {
+    let mut config_file_path = app_data_dir.clone();
+    config_file_path.push(BOOT_CONFIG_FILE_NAME);
+    return config_file_path;
+}
+
+fn set_boot_config(boot_config: &mut BootConfig, value: &Value) {
+    boot_config.last_window_width = match value["last_window_width"].as_u64() {
+        Some(value) => value as u32,
+        None => 0
+    };
+    boot_config.last_window_height = match value["last_window_height"].as_u64() {
+        Some(value) => value as u32,
+        None => 0
+    };
+}
+
+pub fn read_boot_config(app_data_dir: &PathBuf) -> BootConfig {
+    let boot_config_file_path = get_boot_config_file_path(app_data_dir);
+    let mut boot_config = BootConfig {
+        last_window_width: 0,
+        last_window_height: 0
+    };
+    match read_json_file(&boot_config_file_path) {
+        Some(value) =>{
+            set_boot_config(&mut boot_config, &value);
+        }
+        None => {
+            eprintln!("No boot restore config file found {}", boot_config_file_path.display());
+        }
+    }
+    return boot_config;
+}

--- a/src-tauri/src/boot_config.rs
+++ b/src-tauri/src/boot_config.rs
@@ -14,7 +14,7 @@ fn get_boot_config_file_path(app_data_dir: &PathBuf) -> PathBuf {
     return config_file_path;
 }
 
-fn set_boot_config(boot_config: &mut BootConfig, value: &Value) {
+fn _set_boot_config(boot_config: &mut BootConfig, value: &Value) {
     boot_config.last_window_width = match value["last_window_width"].as_u64() {
         Some(value) => value as u32,
         None => 0
@@ -33,7 +33,7 @@ pub fn read_boot_config(app_data_dir: &PathBuf) -> BootConfig {
     };
     match read_json_file(&boot_config_file_path) {
         Some(value) =>{
-            set_boot_config(&mut boot_config, &value);
+            _set_boot_config(&mut boot_config, &value);
         }
         None => {
             eprintln!("No boot restore config file found {}", boot_config_file_path.display());

--- a/src-tauri/src/boot_config.rs
+++ b/src-tauri/src/boot_config.rs
@@ -1,7 +1,19 @@
+use std::sync::Arc;
+use once_cell::sync::OnceCell;
 use serde_json::Value;
+use serde::Serialize;
 use crate::utilities::read_json_file;
 use std::path::PathBuf;
+use std::fs::File;
+use std::io::Write;
 
+pub struct AppConstants {
+    pub tauri_config : Arc<tauri::Config>,
+    pub app_data_dir: std::path::PathBuf
+}
+pub static APP_CONSTANTS: OnceCell<AppConstants> = OnceCell::new();
+
+#[derive(Serialize)]
 pub struct BootConfig {
     pub last_window_width: u32,
     pub last_window_height: u32,
@@ -25,19 +37,39 @@ fn _set_boot_config(boot_config: &mut BootConfig, value: &Value) {
     };
 }
 
-pub fn read_boot_config(app_data_dir: &PathBuf) -> BootConfig {
-    let boot_config_file_path = get_boot_config_file_path(app_data_dir);
+pub fn read_boot_config() -> BootConfig {
     let mut boot_config = BootConfig {
         last_window_width: 0,
         last_window_height: 0
     };
-    match read_json_file(&boot_config_file_path) {
-        Some(value) =>{
-            _set_boot_config(&mut boot_config, &value);
-        }
-        None => {
-            eprintln!("No boot restore config file found {}", boot_config_file_path.display());
+    if let Some(app_constants) = APP_CONSTANTS.get() {
+        let boot_config_file_path = get_boot_config_file_path(&app_constants.app_data_dir);
+        match read_json_file(&boot_config_file_path) {
+            Some(value) =>{
+                _set_boot_config(&mut boot_config, &value);
+            }
+            None => {
+                eprintln!("No boot restore config file found {}", boot_config_file_path.display());
+            }
         }
     }
     return boot_config;
+}
+
+fn _write_boot_config(boot_config: &BootConfig) {
+    if let Some(app_constants) = APP_CONSTANTS.get() {
+        let boot_config_file_path = get_boot_config_file_path(&app_constants.app_data_dir);
+        // Convert the BootConfig struct to JSON
+        let json_string = serde_json::to_string(boot_config).unwrap();
+        let mut file = File::create(boot_config_file_path).expect("Failed to create file");
+        file.write_all(json_string.as_bytes())
+            .expect("Failed to write to boot config file");   
+    }
+}
+
+pub fn write_boot_config(last_window_width: u32, last_window_height: u32) {
+    _write_boot_config(&BootConfig {
+         last_window_width,
+         last_window_height
+     })
 }

--- a/src-tauri/src/init.rs
+++ b/src-tauri/src/init.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+use once_cell::sync::OnceCell;
+use tauri::Manager;
+use crate::utilities::ensure_dir_exists;
+use crate::boot_config::read_boot_config;
+use crate::boot_config::BootConfig;
+
+struct AppConstants {
+    tauri_config : Arc<tauri::Config>,
+    app_data_dir: std::path::PathBuf
+}
+static APP_CONSTANTS: OnceCell<AppConstants> = OnceCell::new();
+static PREFERRED_WIDTH: u32 = 1366;
+static PREFERRED_HEIGHT: u32 = 900;
+static MAXIMIZE_SIZE: u32 = 0;
+
+fn get_window_size(last_saved_size: u32, screen_size: u32, preferred_size: u32) -> u32 {
+    if last_saved_size != 0 && last_saved_size <= screen_size {
+        return last_saved_size;
+    }
+    if preferred_size < screen_size {
+        return preferred_size;
+    }
+    return MAXIMIZE_SIZE;
+}
+
+fn restore_window_size(app: &mut tauri::App, boot_config: &BootConfig){
+    let main_window = app.get_window("main").unwrap();
+    let current_monitor = main_window.current_monitor().unwrap().unwrap();
+    let current_monitor_size = current_monitor.size();
+    println!("current_monitor_size is {}, {}", current_monitor_size.width, current_monitor_size.height);
+    println!("saved window size is {}, {}", boot_config.last_window_width, boot_config.last_window_height);
+    let width = get_window_size(boot_config.last_window_width, current_monitor_size.width, PREFERRED_WIDTH);
+    let height = get_window_size(boot_config.last_window_height, current_monitor_size.height, PREFERRED_HEIGHT);
+    if width == MAXIMIZE_SIZE || height == MAXIMIZE_SIZE {
+        main_window.maximize().expect("unable to maximize");
+    } else {
+        println!("resizing window to {}, {}", width, height);
+        let size = tauri::PhysicalSize::new(width, height);
+        main_window.set_size(size).expect("unable to resize");
+    }
+}
+
+pub fn init_app(app: &mut tauri::App) {
+    let config = app.config().clone();
+    let _ = APP_CONSTANTS.set(AppConstants {
+        tauri_config: config.clone(),
+        app_data_dir: tauri::api::path::app_data_dir(&config).expect("failed to retrieve app_data_dir")
+            .canonicalize().expect("Failed to canonicalize app_data_dir")
+    });
+
+    // To get a value
+    if let Some(app_constants) = APP_CONSTANTS.get() {
+        println!("Appdata Dir is {}", app_constants.app_data_dir.display());
+        ensure_dir_exists(&app_constants.app_data_dir);
+        let boot_config = read_boot_config(&app_constants.app_data_dir);
+        restore_window_size(app, &boot_config);
+    }
+}

--- a/src-tauri/src/init.rs
+++ b/src-tauri/src/init.rs
@@ -51,6 +51,7 @@ pub fn init_app(app: &mut tauri::App) {
 
     // To get a value
     if let Some(app_constants) = APP_CONSTANTS.get() {
+        println!("Bundle ID is {}", app_constants.tauri_config.tauri.bundle.identifier);
         println!("Appdata Dir is {}", app_constants.app_data_dir.display());
         ensure_dir_exists(&app_constants.app_data_dir);
         let boot_config = read_boot_config(&app_constants.app_data_dir);

--- a/src-tauri/src/init.rs
+++ b/src-tauri/src/init.rs
@@ -1,21 +1,17 @@
-use std::sync::Arc;
-use once_cell::sync::OnceCell;
 use tauri::Manager;
 use crate::utilities::ensure_dir_exists;
 use crate::boot_config::read_boot_config;
 use crate::boot_config::BootConfig;
+use crate::boot_config::APP_CONSTANTS;
+use crate::boot_config::AppConstants;
 
-struct AppConstants {
-    tauri_config : Arc<tauri::Config>,
-    app_data_dir: std::path::PathBuf
-}
-static APP_CONSTANTS: OnceCell<AppConstants> = OnceCell::new();
 static PREFERRED_WIDTH: u32 = 1366;
 static PREFERRED_HEIGHT: u32 = 900;
 static MAXIMIZE_SIZE: u32 = 0;
 
 fn get_window_size(last_saved_size: u32, screen_size: u32, preferred_size: u32) -> u32 {
-    if last_saved_size != 0 && last_saved_size <= screen_size {
+    if last_saved_size != 0 {
+        // we dont do last_saved_size<screen_size here as we leave it to os to deal with windows larger than screen size
         return last_saved_size;
     }
     if preferred_size < screen_size {
@@ -54,7 +50,7 @@ pub fn init_app(app: &mut tauri::App) {
         println!("Bundle ID is {}", app_constants.tauri_config.tauri.bundle.identifier);
         println!("Appdata Dir is {}", app_constants.app_data_dir.display());
         ensure_dir_exists(&app_constants.app_data_dir);
-        let boot_config = read_boot_config(&app_constants.app_data_dir);
+        let boot_config = read_boot_config();
         restore_window_size(app, &boot_config);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,9 @@ windows_subsystem = "windows"
 )]
 
 use tauri::api::process::Command;
+mod init;
+mod utilities;
+mod boot_config;
 
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command]
@@ -20,9 +23,10 @@ fn greet(handle: tauri::AppHandle, name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+static mut DEVTOOLS_LOADED:bool = false;
+
 #[tauri::command]
 fn toggle_devtools(window: tauri::Window) {
-    static mut DEVTOOLS_LOADED:bool = false;
     unsafe {
         // though unsafe, this is fine as its just a view toggle and not mission critical.
         if !DEVTOOLS_LOADED {
@@ -36,6 +40,10 @@ fn toggle_devtools(window: tauri::Window) {
 
 fn main() {
     tauri::Builder::default()
+        .setup(|app| {
+            init::init_app(app);
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![greet, toggle_devtools])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,18 +42,19 @@ fn toggle_devtools(window: tauri::Window) {
 fn process_window_event(event: &GlobalWindowEvent) {
     if let tauri::WindowEvent::CloseRequested { .. } = event.event() {
         let size = event.window().outer_size().unwrap();
-        println!("Window closing {}, {}", size.width, size.height);
+        println!("Window closing size {}, {}", size.width, size.height);
+        boot_config::write_boot_config(size.width, size.height);
     }
 }
 
 fn main() {
     tauri::Builder::default()
+        .on_window_event(|event| process_window_event(&event))
+        .invoke_handler(tauri::generate_handler![greet, toggle_devtools])
         .setup(|app| {
             init::init_app(app);
             Ok(())
         })
-        .on_window_event(|event| process_window_event(&event))
-        .invoke_handler(tauri::generate_handler![greet, toggle_devtools])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ windows_subsystem = "windows"
 )]
 
 use tauri::api::process::Command;
+use tauri::GlobalWindowEvent;
 mod init;
 mod utilities;
 mod boot_config;
@@ -38,12 +39,20 @@ fn toggle_devtools(window: tauri::Window) {
     }
 }
 
+fn process_window_event(event: &GlobalWindowEvent) {
+    if let tauri::WindowEvent::CloseRequested { .. } = event.event() {
+        let size = event.window().outer_size().unwrap();
+        println!("Window closing {}, {}", size.width, size.height);
+    }
+}
+
 fn main() {
     tauri::Builder::default()
         .setup(|app| {
             init::init_app(app);
             Ok(())
         })
+        .on_window_event(|event| process_window_event(&event))
         .invoke_handler(tauri::generate_handler![greet, toggle_devtools])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/utilities.rs
+++ b/src-tauri/src/utilities.rs
@@ -1,0 +1,61 @@
+use std::fs;
+use serde_json;
+use std::path::PathBuf;
+use std::fs::File;
+use std::io::Read;
+use serde_json::Value;
+
+/// This function prints the type of the input value.
+///
+/// It uses Rust's reflection capabilities to determine and print the type
+/// of the input. This can be useful for debugging and understanding
+/// what types are being used in certain parts of your code.
+///
+/// # Examples
+///
+/// ```
+/// let x = 5;
+/// print_type_of(&x);
+/// // prints: "i32"
+/// ```
+///
+/// # Panics
+///
+/// This function does not panic.
+///
+/// # Errors
+///
+/// This function does not return any errors.
+pub fn print_type_of<T>(_: &T) {
+    println!("{}", std::any::type_name::<T>());
+}
+
+pub fn ensure_dir_exists(path: &PathBuf){
+    if let Err(e) = fs::create_dir_all(path) {
+        eprintln!("Failed to create directory: {}", e);
+    } else {
+        println!("Directory created successfully {}", path.display());
+    }
+}
+
+pub fn read_json_file(path: &PathBuf) -> Option<Value> {
+    let filename = match path.to_str() {
+        Some(file) => file.to_string(), // Convert &str to String
+        None => return None, // File not present or cannot be opened
+    };
+
+    let mut file = match File::open(filename) {
+        Ok(file) => file,
+        Err(_) => return None, // File not present or cannot be opened
+    };
+
+    let mut contents = String::new();
+    if let Err(_) = file.read_to_string(&mut contents) {
+        return None; // Error reading the file
+    }
+
+    match serde_json::from_str(&contents) {
+        Ok(data) => Some(data),
+        Err(_) => None, // JSON parsing error
+    }
+}

--- a/src-tauri/src/utilities.rs
+++ b/src-tauri/src/utilities.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 ///
 /// ```
 /// let x = 5;
-/// print_type_of(&x);
+/// _print_type_of(&x);
 /// // prints: "i32"
 /// ```
 ///
@@ -26,7 +26,7 @@ use serde_json::Value;
 /// # Errors
 ///
 /// This function does not return any errors.
-pub fn print_type_of<T>(_: &T) {
+pub fn _print_type_of<T>(_: &T) {
     println!("{}", std::any::type_name::<T>());
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,7 +53,7 @@
                 "icons/icon.icns",
                 "icons/icon.ico"
             ],
-            "identifier": "dev.phcode",
+            "identifier": "io.phcode",
             "longDescription": "Phoenix is a modern open-source IDE for the web, built for the browser",
             "macOS": {
                 "entitlements": "../entitlements.plist",


### PR DESCRIPTION
Implemented functionality to resize the window to its last known size on application startup, if available.
* If the last known size is not available, the window will be set to a preferred size that ensures the app looks good (an arbitrary size obtained through manual testing and media queries for the new project window).
* If the preferred size exceeds the screen size, the window will be maximized to fit the available space.