### PR TITLE
ci: change bundle id based on stage to create different browser webview profiles for stage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "phoenix-code-ide",
     "private": true,
-    "version": "3.2.2",
+    "version": "3.2.6",
     "type": "module",
     "scripts": {
         "tauri": "tauri",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "phoenix-code-ide",
     "private": true,
-    "version": "3.2.6",
+    "version": "3.2.2",
     "type": "module",
     "scripts": {
         "tauri": "tauri",

--- a/src-build/ci-createDistReleaseConfig.js
+++ b/src-build/ci-createDistReleaseConfig.js
@@ -2,6 +2,7 @@ import {fileURLToPath} from "url";
 import {dirname, join} from "path";
 import {
     PRODUCT_NAME_SUFFIX_FOR_STAGE,
+    BUNDLE_IDENTIFIER_FOR_STAGE,
     UPDATE_NOTIFICATION_LATEST_JSON_FILE_PATH,
     UPDATE_NOTIFICATIONS_BASE_URL
 } from "./constants.js";
@@ -75,6 +76,9 @@ async function ciCreateDistReleaseConfig() {
     configJson.tauri.updater.endpoints = [
         `${UPDATE_NOTIFICATIONS_BASE_URL}${UPDATE_NOTIFICATION_LATEST_JSON_FILE_PATH[phoenixStage]}`
     ];
+    const bundleIdentifier = BUNDLE_IDENTIFIER_FOR_STAGE[phoenixStage] || "io.phcode.unknown.stage";
+    console.log("Product Bundle Identifier is: ", bundleIdentifier);
+    configJson.tauri.bundle.identifier = bundleIdentifier;
     console.log("Product update endpoints are: ", configJson.tauri.updater.endpoints);
     console.log("Writing new dist config json ", tauriConfigPath);
     fs.writeFileSync(tauriConfigPath, JSON.stringify(configJson, null, 4));

--- a/src-build/constants.js
+++ b/src-build/constants.js
@@ -6,6 +6,12 @@ export const PRODUCT_NAME_SUFFIX_FOR_STAGE = {
     production: "" // has no suffix
 };
 
+export const BUNDLE_IDENTIFIER_FOR_STAGE = {
+    dev : "io.phcode.dev",
+    stage: "io.phcode.staging",
+    production: "io.phcode"
+};
+
 export const UPDATE_NOTIFICATION_LATEST_JSON_FILE_PATH = {
     // do not change any of these names unless you want to nuke the updater for all the whole installation base!!
     // or you know what you are doing.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-code-ide"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "once_cell",
  "serde",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
                 "icons/icon.icns",
                 "icons/icon.ico"
             ],
-            "identifier": "io.phcode",
+            "identifier": "io.phcode.dev",
             "longDescription": "Phoenix is a modern open-source IDE for the web, built for the browser",
             "macOS": {
                 "entitlements": "../entitlements.plist",
@@ -170,7 +170,8 @@
                 "resizable": true,
                 "title": "Phoenix Code",
                 "width": 1024,
-                "minWidth": 800
+                "minWidth": 800,
+                "acceptFirstMouse": true
             }
         ]
     }


### PR DESCRIPTION
Else, all stages will use the same browser storage like local storage / indexed db and will cross contaminate installed builds with dev build data.