### PR TITLE
refactor: tauri already has os.tempdir api, so removing our impl

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,11 +46,6 @@ fn toggle_devtools(window: tauri::Window) {
     }
 }
 
-#[tauri::command]
-fn get_temp_dir() -> String {
-    std::env::temp_dir().into_os_string().into_string().unwrap()
-}
-
 fn process_window_event(event: &GlobalWindowEvent) {
     if let tauri::WindowEvent::CloseRequested { .. } = event.event() {
         let size = event.window().outer_size().unwrap();
@@ -65,7 +60,7 @@ fn main() {
         .on_window_event(|event| process_window_event(&event))
         .invoke_handler(tauri::generate_handler![
             toggle_devtools, console_log, console_error,
-            _get_windows_drives, _rename_path, get_temp_dir])
+            _get_windows_drives, _rename_path])
         .setup(|app| {
             init::init_app(app);
             Ok(())


### PR DESCRIPTION
related: https://github.com/phcode-dev/phoenix/pull/1136