### PR TITLE
chore: cache bursting using version prefixes

### DIFF
--- a/src-build/ci-createDistReleaseConfig.js
+++ b/src-build/ci-createDistReleaseConfig.js
@@ -73,9 +73,9 @@ async function ciCreateDistReleaseConfig() {
     console.log("Product name is: ", configJson.package.productName);
     configJson.tauri.windows[0].title = configJson.package.productName;
     if(os.platform() === 'win32'){
-        configJson.tauri.windows[0].url = "https://phcode.localhost/";
+        configJson.tauri.windows[0].url = `https://phcode.localhost/v${phoenixVersion}/`;
     } else {
-        configJson.tauri.windows[0].url = "phcode://localhost/";
+        configJson.tauri.windows[0].url = `phcode://localhost/v${phoenixVersion}/`;
     }
     console.log("Window Boot url is: ", configJson.tauri.windows[0].url);
     configJson.tauri.updater.endpoints = [

--- a/src-build/createDistReleaseConfig.js
+++ b/src-build/createDistReleaseConfig.js
@@ -20,10 +20,11 @@ async function createDistReleaseConfig() {
     console.log(chalk.cyan("\n!Only creating executables. Creating msi, appimage and dmg installers are disabled in this build. If you want to create an installer, use: npm run tauri build manually after setting distDir in tauri conf!\n"));
     configJson.tauri.bundle.active = false;
     configJson.build.distDir = '../../phoenix/dist/';
+    const phoenixVersion = configJson.package.version;
     if(os.platform() === 'win32'){
-        configJson.tauri.windows[0].url = "https://phcode.localhost/";
+        configJson.tauri.windows[0].url = `https://phcode.localhost/v${phoenixVersion}/`;
     } else {
-        configJson.tauri.windows[0].url = "phcode://localhost/";
+        configJson.tauri.windows[0].url = `phcode://localhost/v${phoenixVersion}/`;
     }
     console.log("Window Boot url is: ", configJson.tauri.windows[0].url);
     console.log("Writing new local config json ", tauriLocalConfigPath);

--- a/src-build/createDistTestReleaseConfig.js
+++ b/src-build/createDistTestReleaseConfig.js
@@ -22,10 +22,11 @@ async function createDistTestReleaseConfig() {
     console.log(chalk.cyan("\n!Only creating executables. Creating msi, appimage and dmg installers are disabled in this build. If you want to create an installer, use: npm run tauri build manually after setting distDir in tauri conf!\n"));
     configJson.tauri.bundle.active = false;
     configJson.build.distDir = '../../phoenix/dist-test/';
+    const phoenixVersion = configJson.package.version;
     if(os.platform() === 'win32'){
-        configJson.tauri.windows[0].url = "https://phcode.localhost/";
+        configJson.tauri.windows[0].url = `https://phcode.localhost/v${phoenixVersion}/`;
     } else {
-        configJson.tauri.windows[0].url = "phcode://localhost/";
+        configJson.tauri.windows[0].url = `phcode://localhost/v${phoenixVersion}/`;
     }
     console.log("Window Boot url is: ", configJson.tauri.windows[0].url);
     console.log("Writing new local config json ", tauriLocalConfigPath);

--- a/src-build/createSrcReleaseConfig.js
+++ b/src-build/createSrcReleaseConfig.js
@@ -20,10 +20,11 @@ async function createSrcReleaseConfig() {
     console.log(chalk.cyan("\n!Only creating executables. Creating msi, appimage and dmg installers are disabled in this build. If you want to create an installer, use: npm run tauri build manually after setting distDir in tauri conf!\n"));
     configJson.tauri.bundle.active = false;
     configJson.build.distDir = '../../phoenix/src/'
+    const phoenixVersion = configJson.package.version;
     if(os.platform() === 'win32'){
-        configJson.tauri.windows[0].url = "https://phcode.localhost/";
+        configJson.tauri.windows[0].url = `https://phcode.localhost/v${phoenixVersion}/`;
     } else {
-        configJson.tauri.windows[0].url = "phcode://localhost/";
+        configJson.tauri.windows[0].url = `phcode://localhost/v${phoenixVersion}/`;
     }
     console.log("Window Boot url is: ", configJson.tauri.windows[0].url);
     console.log("Writing new local config json ", tauriLocalConfigPath);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1876,7 +1876,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1887,9 +1887,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -2428,6 +2428,7 @@ version = "3.2.11"
 dependencies = [
  "once_cell",
  "percent-encoding",
+ "regex",
  "serde",
  "serde_json",
  "tauri",
@@ -2703,13 +2704,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick 1.0.2",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2722,6 +2724,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick 1.0.2",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,9 +2742,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { version = "1.5.0", features = [] }
 serde_json = "1.0"
 once_cell = "1.18.0"
 percent-encoding = "2.3"
+regex = "1.9.1"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.2", features = [ "cli", "api-all", "updater", "devtools", "linux-protocol-headers"] }
 winapi = { version = "0.3", features = ["fileapi"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -148,7 +148,7 @@ fn main() {
             let builder = ResponseBuilder::new()
                 .header("Access-Control-Allow-Origin", window_origin)
                 .header("Origin", window_origin)
-                .header("Cache-Control", "private, max-age=31536000, immutable") // 1 year cache age expiry
+                .header("Cache-Control", "private, max-age=7776000, immutable") // 3 month cache age expiry
                 .mimetype(&asset.mime_type);
 
             let response = builder.body(asset.bytes)?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -228,8 +228,39 @@
                         "fs-extra"
                     ],
                     "windows": [
-                        "main"
+                        "main",
+                        "phcode-1",
+                        "phcode-2",
+                        "phcode-3",
+                        "phcode-4",
+                        "phcode-5",
+                        "phcode-6",
+                        "phcode-7",
+                        "phcode-8",
+                        "phcode-9",
+                        "phcode-10",
+                        "phcode-11",
+                        "phcode-12",
+                        "phcode-13",
+                        "phcode-14",
+                        "phcode-15",
+                        "phcode-16",
+                        "phcode-17",
+                        "phcode-18",
+                        "phcode-19",
+                        "phcode-20",
+                        "phcode-21",
+                        "phcode-22",
+                        "phcode-23",
+                        "phcode-24",
+                        "phcode-25",
+                        "phcode-26",
+                        "phcode-27",
+                        "phcode-28",
+                        "phcode-29",
+                        "phcode-30"
                     ]
+
                 },
                 {
                     "scheme": "https",
@@ -239,7 +270,37 @@
                         "fs-extra"
                     ],
                     "windows": [
-                        "main"
+                        "main",
+                        "phcode-1",
+                        "phcode-2",
+                        "phcode-3",
+                        "phcode-4",
+                        "phcode-5",
+                        "phcode-6",
+                        "phcode-7",
+                        "phcode-8",
+                        "phcode-9",
+                        "phcode-10",
+                        "phcode-11",
+                        "phcode-12",
+                        "phcode-13",
+                        "phcode-14",
+                        "phcode-15",
+                        "phcode-16",
+                        "phcode-17",
+                        "phcode-18",
+                        "phcode-19",
+                        "phcode-20",
+                        "phcode-21",
+                        "phcode-22",
+                        "phcode-23",
+                        "phcode-24",
+                        "phcode-25",
+                        "phcode-26",
+                        "phcode-27",
+                        "phcode-28",
+                        "phcode-29",
+                        "phcode-30"
                     ]
                 }
             ]


### PR DESCRIPTION
When we install a version say `1.1.1`, we usually set cache HTTP headers so that we cache the HTTP requests for a year.

So when we upgrade to v1.1.2, it may serve the old caches HTML files from the browser cache instead of the new files.
So to burst the cache, we prepend the version string to base URLs like `http://localhost/v1.1.1/` 