### PR TITLE
build: npm run tauriBuildDemoApp to build demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ The actual release artifacts will then be built by the tauri action `tauri-apps/
 Remember, the `npm run _ci-*` commands are designed to execute in the GitHub Actions environment.
 They're not typically used for local machine executions unless you're working on or testing the GitHub Actions workflows themselves.
 
+### Building the demo app
+If you dont want to build phcode and just build a demo app with similar config as phcode(You may do this
+if you are working on the release generation or build tooling and don't want to wait for phcode to build
+every time you want to test the build). Just run this command:
+
+```bash
+npm run tauriBuildDemoApp
+```
+
 # License
 
 GNU AGPL-3.0 License

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "tauri": "tauri",
-        "build": "",
+        "tauriBuildDemoApp": "node src-build/createDemoReleaseConfig.js && tauri build --config ./src-tauri/tauri-local.conf.json",
         "_createSrcReleaseConfig": "node src-build/createSrcReleaseConfig.js",
         "_createDistReleaseConfig": "node src-build/createDistReleaseConfig.js",
         "_createDistTestReleaseConfig": "node src-build/createDistTestReleaseConfig.js",

--- a/src-build/createDemoReleaseConfig.js
+++ b/src-build/createDemoReleaseConfig.js
@@ -1,0 +1,26 @@
+import {fileURLToPath} from "url";
+import {dirname} from "path";
+import fs from 'fs';
+import * as os from 'os';
+
+import {getPlatformDetails} from "./utils.js";
+import chalk from "chalk";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+async function createSrcReleaseConfig() {
+    const platform = getPlatformDetails().platform;
+    const tauriConfigPath = (platform === "win") ? `${__dirname}\\..\\src-tauri\\tauri.conf.json`
+        : `${__dirname}/../src-tauri/tauri.conf.json`;
+    const tauriLocalConfigPath = (platform === "win") ? `${__dirname}\\..\\src-tauri\\tauri-local.conf.json`
+        : `${__dirname}/../src-tauri/tauri-local.conf.json`;
+    console.log("Reading config file: ", tauriConfigPath);
+    let configJson = JSON.parse(fs.readFileSync(tauriConfigPath));
+    console.log(chalk.cyan("\n!Creating the demo app!\n"));
+    configJson.tauri.bundle.resources = []; // no resources packaged in demo app
+    console.log("Writing new local config json ", tauriLocalConfigPath);
+    fs.writeFileSync(tauriLocalConfigPath, JSON.stringify(configJson, null, 4));
+}
+
+await createSrcReleaseConfig();


### PR DESCRIPTION
### Building the demo app
If you dont want to build phcode and just build a demo app with similar config as phcode(You may do this
if you are working on the release generation or build tooling and don't want to wait for phcode to build
every time you want to test the build). Just run this command:

```bash
npm run tauriBuildDemoApp
```