### PR TITLE
chore: change phcode protocol to phtauri as its interfering with phcode.site and other domains in windows

### DIFF
--- a/src-build/ci-createDistReleaseConfig.js
+++ b/src-build/ci-createDistReleaseConfig.js
@@ -74,9 +74,9 @@ async function ciCreateDistReleaseConfig() {
     console.log("Product name is: ", configJson.package.productName);
     configJson.tauri.windows[0].title = configJson.package.productName;
     if(os.platform() === 'win32'){
-        configJson.tauri.windows[0].url = `https://phcode.localhost/v${phoenixVersion}/`;
+        configJson.tauri.windows[0].url = `https://phtauri.localhost/v${phoenixVersion}/`;
     } else {
-        configJson.tauri.windows[0].url = `phcode://localhost/v${phoenixVersion}/`;
+        configJson.tauri.windows[0].url = `phtauri://localhost/v${phoenixVersion}/`;
     }
     console.log("Window Boot url is: ", configJson.tauri.windows[0].url);
     configJson.tauri.updater.endpoints = [

--- a/src-build/createDistReleaseConfig.js
+++ b/src-build/createDistReleaseConfig.js
@@ -22,9 +22,9 @@ async function createDistReleaseConfig() {
     configJson.build.distDir = '../../phoenix/dist/';
     const phoenixVersion = configJson.package.version;
     if(os.platform() === 'win32'){
-        configJson.tauri.windows[0].url = `https://phcode.localhost/v${phoenixVersion}/`;
+        configJson.tauri.windows[0].url = `https://phtauri.localhost/v${phoenixVersion}/`;
     } else {
-        configJson.tauri.windows[0].url = `phcode://localhost/v${phoenixVersion}/`;
+        configJson.tauri.windows[0].url = `phtauri://localhost/v${phoenixVersion}/`;
     }
     console.log("Window Boot url is: ", configJson.tauri.windows[0].url);
     console.log("Writing new local config json ", tauriLocalConfigPath);

--- a/src-build/createDistTestReleaseConfig.js
+++ b/src-build/createDistTestReleaseConfig.js
@@ -24,9 +24,9 @@ async function createDistTestReleaseConfig() {
     configJson.build.distDir = '../../phoenix/dist-test/';
     const phoenixVersion = configJson.package.version;
     if(os.platform() === 'win32'){
-        configJson.tauri.windows[0].url = `https://phcode.localhost/v${phoenixVersion}/`;
+        configJson.tauri.windows[0].url = `https://phtauri.localhost/v${phoenixVersion}/`;
     } else {
-        configJson.tauri.windows[0].url = `phcode://localhost/v${phoenixVersion}/`;
+        configJson.tauri.windows[0].url = `phtauri://localhost/v${phoenixVersion}/`;
     }
     console.log("Window Boot url is: ", configJson.tauri.windows[0].url);
     console.log("Writing new local config json ", tauriLocalConfigPath);

--- a/src-build/createSrcReleaseConfig.js
+++ b/src-build/createSrcReleaseConfig.js
@@ -22,9 +22,9 @@ async function createSrcReleaseConfig() {
     configJson.build.distDir = '../../phoenix/src/'
     const phoenixVersion = configJson.package.version;
     if(os.platform() === 'win32'){
-        configJson.tauri.windows[0].url = `https://phcode.localhost/v${phoenixVersion}/`;
+        configJson.tauri.windows[0].url = `https://phtauri.localhost/v${phoenixVersion}/`;
     } else {
-        configJson.tauri.windows[0].url = `phcode://localhost/v${phoenixVersion}/`;
+        configJson.tauri.windows[0].url = `phtauri://localhost/v${phoenixVersion}/`;
     }
     console.log("Window Boot url is: ", configJson.tauri.windows[0].url);
     console.log("Writing new local config json ", tauriLocalConfigPath);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -120,9 +120,18 @@ fn remove_version_from_url(url: &str) -> String {
 
 fn main() {
     tauri::Builder::default()
-        .register_uri_scheme_protocol("phcode", move |app, request| { // can't use `tauri` because that's already in use
+        .register_uri_scheme_protocol("phtauri", move |app, request| { // can't use `tauri` because that's already in use
             let path = remove_version_from_url(request.uri());
-            let path = path.strip_prefix("phcode://localhost").unwrap();
+            let path = path.strip_prefix("phtauri://localhost");
+            if path.is_none() {
+                let not_found_response = ResponseBuilder::new()
+                    .status(404)
+                    .mimetype("text/html")
+                    .body("Asset not found".as_bytes().to_vec())
+                    .unwrap();
+                return Ok(not_found_response);
+            }
+            let path = path.unwrap();
             let path = percent_encoding::percent_decode(path.as_bytes())
                 .decode_utf8_lossy()
                 .to_string();
@@ -143,9 +152,9 @@ fn main() {
             let asset = asset_option.unwrap();
 
             #[cfg(windows)]
-                let window_origin = "https://phcode.localhost";
+                let window_origin = "https://phtauri.localhost";
             #[cfg(not(windows))]
-                let window_origin = "phcode://localhost";
+                let window_origin = "phtauri://localhost";
 
             let builder = ResponseBuilder::new()
                 .header("Access-Control-Allow-Origin", window_origin)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -223,7 +223,7 @@
             "dangerousDisableAssetCspModification": true,
             "dangerousRemoteDomainIpcAccess": [
                 {
-                    "scheme": "phcode",
+                    "scheme": "phtauri",
                     "domain": "localhost",
                     "enableTauriAPI": true,
                     "plugins": [
@@ -266,7 +266,7 @@
                 },
                 {
                     "scheme": "https",
-                    "domain": "phcode.localhost",
+                    "domain": "phtauri.localhost",
                     "enableTauriAPI": true,
                     "plugins": [
                         "fs-extra"


### PR DESCRIPTION
tauri bug in windows for custom protocol that redirects `fetch(https://phcode.site)` to our rust custom protocol handler as `phcode://site`

used phtauri as it doesnt seem likely to conflict with any domains