### PR TITLE
refactor: use tauri window position restore plugins instead of self impl

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -200,7 +200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3d816ce6f0e2909a96830d6911c2aff044370b1ef92d7f267b43bae5addedd"
 dependencies = [
  "atk-sys",
- "bitflags",
+ "bitflags 1.3.2",
  "glib",
  "libc",
 ]
@@ -268,10 +268,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block"
@@ -367,7 +382,7 @@ version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c76ee391b03d35510d9fa917357c7f1855bd9a6659c95a1b392e33f49b3369bc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -463,7 +478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap 1.9.3",
  "strsim",
@@ -486,7 +501,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
  "core-foundation",
@@ -502,7 +517,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-foundation",
  "core-graphics-types",
@@ -564,7 +579,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -577,7 +592,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "libc",
 ]
@@ -1057,7 +1072,7 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e05c1f572ab0e1f15be94217f0dc29088c248b14f792a5ff0af0d84bcda9e8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "gdk-pixbuf",
  "gdk-sys",
@@ -1073,7 +1088,7 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38dd9cc8b099cceecdf41375bb6d481b1b5a7cd5cd603e10a69a9383f8619a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gdk-pixbuf-sys",
  "gio",
  "glib",
@@ -1194,7 +1209,7 @@ version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68fdbc90312d462781a395f7a16d96a2b379bb6ef8cd6310a2df272771c4283b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1224,7 +1239,7 @@ version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb0306fbad0ab5428b0ca674a23893db909a98582969c9b537be4ced78c505d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1300,7 +1315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e3004a2d5d6d8b5057d2b57b3712c9529b62e82c77f25c1fecde1fd5c23bd0"
 dependencies = [
  "atk",
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "field-offset",
  "futures-channel",
@@ -1673,7 +1688,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf053e7843f2812ff03ef5afe34bb9c06ffee120385caad4f6b9967fcd37d41c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "glib",
  "javascriptcore-rs-sys",
 ]
@@ -1966,7 +1981,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
  "num_enum",
@@ -2000,7 +2015,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
@@ -2167,7 +2182,7 @@ version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2254,7 +2269,7 @@ version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e4045548659aee5313bde6c582b0d83a627b7904dd20dc2d9ef0895d414e4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "glib",
  "libc",
  "once_cell",
@@ -2434,6 +2449,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-fs-extra",
+ "tauri-plugin-window-state",
  "winapi",
 ]
 
@@ -2475,7 +2491,7 @@ version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2489,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -2679,7 +2695,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2688,7 +2704,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2830,7 +2846,7 @@ version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2892,7 +2908,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2915,7 +2931,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cssparser",
  "derive_more",
  "fxhash",
@@ -3164,7 +3180,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b4d76501d8ba387cf0fefbe055c3e0a59891d09f0f995ae4e4b16f6b60f3c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gio",
  "glib",
  "libc",
@@ -3178,7 +3194,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009ef427103fcb17f802871647a7fa6c60cbb654b4c4e4c0ac60a31c5f6dc9cf"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gio-sys",
  "glib-sys",
  "gobject-sys",
@@ -3306,7 +3322,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6d198e01085564cea63e976ad1566c1ba2c2e4cc79578e35d9f05521505e31"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "cc",
  "cocoa",
@@ -3497,8 +3513,22 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-fs-extra"
 version = "0.0.0"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#5b814f56e6368fdec46c4ddb04a07e0923ff995a"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#3db81b4fe30d2ddb9cc109852b90b1e37da9e4cd"
 dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "0.1.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#3db81b4fe30d2ddb9cc109852b90b1e37da9e4cd"
+dependencies = [
+ "bincode",
+ "bitflags 2.4.1",
  "log",
  "serde",
  "serde_json",
@@ -4134,7 +4164,7 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f859735e4a452aeb28c6c56a852967a8a76c8eb1cc32dbf931ad28a13d6370"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "gdk",
  "gdk-sys",
@@ -4159,7 +4189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d76ca6ecc47aeba01ec61e480139dda143796abcae6f83bcddf50d6b5b1dcf3"
 dependencies = [
  "atk-sys",
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gdk-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.2", features = [ "cli", "api-all", "updater", "devtools", "linux-protocol-headers"] }
 winapi = { version = "0.3", features = ["fileapi"] }
 tauri-plugin-fs-extra = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
+tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/boot_config.rs
+++ b/src-tauri/src/boot_config.rs
@@ -15,8 +15,7 @@ pub static APP_CONSTANTS: OnceCell<AppConstants> = OnceCell::new();
 
 #[derive(Serialize)]
 pub struct BootConfig {
-    pub last_window_width: u32,
-    pub last_window_height: u32,
+    pub version: u32
 }
 static BOOT_CONFIG_FILE_NAME: &'static str = "boot_config.json";
 
@@ -27,11 +26,7 @@ fn get_boot_config_file_path(app_local_data_dir: &PathBuf) -> PathBuf {
 }
 
 fn _set_boot_config(boot_config: &mut BootConfig, value: &Value) {
-    boot_config.last_window_width = match value["last_window_width"].as_u64() {
-        Some(value) => value as u32,
-        None => 0
-    };
-    boot_config.last_window_height = match value["last_window_height"].as_u64() {
+    boot_config.version = match value["version"].as_u64() {
         Some(value) => value as u32,
         None => 0
     };
@@ -39,8 +34,7 @@ fn _set_boot_config(boot_config: &mut BootConfig, value: &Value) {
 
 pub fn read_boot_config() -> BootConfig {
     let mut boot_config = BootConfig {
-        last_window_width: 0,
-        last_window_height: 0
+        version: 1
     };
     if let Some(app_constants) = APP_CONSTANTS.get() {
         let boot_config_file_path = get_boot_config_file_path(&app_constants.app_local_data_dir);
@@ -67,9 +61,9 @@ fn _write_boot_config(boot_config: &BootConfig) {
     }
 }
 
-pub fn write_boot_config(last_window_width: u32, last_window_height: u32) {
+// WARNING: If there are multiple windows, this will be called on each window close.
+pub fn write_boot_config(version: u32) {
     _write_boot_config(&BootConfig {
-         last_window_width,
-         last_window_height
+         version
      })
 }

--- a/src-tauri/src/init.rs
+++ b/src-tauri/src/init.rs
@@ -1,50 +1,7 @@
-use tauri::Manager;
 use crate::utilities::ensure_dir_exists;
 use crate::boot_config::read_boot_config;
-use crate::boot_config::BootConfig;
 use crate::boot_config::APP_CONSTANTS;
 use crate::boot_config::AppConstants;
-
-static PREFERRED_WIDTH: u32 = 1366;
-static PREFERRED_HEIGHT: u32 = 900;
-static MAXIMIZE_SIZE: u32 = 0;
-
-fn get_window_size(last_saved_size: u32, screen_size: u32, preferred_size: u32) -> u32 {
-    if last_saved_size != 0 {
-        // we dont do last_saved_size<screen_size here as we leave it to os to deal with windows larger than screen size
-        return last_saved_size;
-    }
-    if preferred_size < screen_size {
-        return preferred_size;
-    }
-    return MAXIMIZE_SIZE;
-}
-
-fn restore_window_size(app: &mut tauri::App, boot_config: &BootConfig){
-    let main_window = app.get_window("main").unwrap();
-    let current_monitor = main_window.current_monitor().unwrap().unwrap();
-    let current_monitor_size = current_monitor.size();
-
-    #[cfg(debug_assertions)]
-    {
-        println!("current_monitor_size is {}, {}", current_monitor_size.width, current_monitor_size.height);
-        println!("saved window size is {}, {}", boot_config.last_window_width, boot_config.last_window_height);
-    }
-
-    let width = get_window_size(boot_config.last_window_width, current_monitor_size.width, PREFERRED_WIDTH);
-    let height = get_window_size(boot_config.last_window_height, current_monitor_size.height, PREFERRED_HEIGHT);
-    if width == MAXIMIZE_SIZE || height == MAXIMIZE_SIZE {
-        main_window.maximize().expect("unable to maximize");
-    } else {
-
-        #[cfg(debug_assertions)]{
-            println!("resizing window to {}, {}", width, height);
-        }
-
-        let size = tauri::PhysicalSize::new(width, height);
-        main_window.set_size(size).expect("unable to resize");
-    }
-}
 
 pub fn init_app(app: &mut tauri::App) {
     let config = app.config().clone();
@@ -62,7 +19,9 @@ pub fn init_app(app: &mut tauri::App) {
             println!("Bundle ID is {}", app_constants.tauri_config.tauri.bundle.identifier);
         }
         ensure_dir_exists(&app_constants.app_local_data_dir);
-        let boot_config = read_boot_config();
-        restore_window_size(app, &boot_config);
+        read_boot_config();
+        #[cfg(debug_assertions)]{
+            println!("Bootconfig version is {}", read_boot_config().version);
+        }
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -107,8 +107,8 @@ fn show_in_folder(path: String) {
 
 fn process_window_event(event: &GlobalWindowEvent) {
     if let tauri::WindowEvent::CloseRequested { .. } = event.event() {
-        let size = event.window().inner_size().unwrap();
-        boot_config::write_boot_config(size.width, size.height);
+        // this does nothing and is here if in future you need to persist something on window close.
+        boot_config::write_boot_config(1);
     }
 }
 
@@ -166,6 +166,7 @@ fn main() {
             Ok(response)
         })
         .plugin(tauri_plugin_fs_extra::init())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .on_window_event(|event| process_window_event(&event))
         .invoke_handler(tauri::generate_handler![
             toggle_devtools, console_log, console_error,


### PR DESCRIPTION
Earlier we didnt know about this tauri plugin, so migrating away from our own impl.

Tauri's impl is much more consistant and fixes bugs. Now the restore will
1. Remember windows positions and sizes for every window opened.
2. remebers which display to use if there are multiple displays. our impl didnt handle this.
3. The windows posisioning is now much more consistant than our impl and feels aligned with the os window placement logic.