### PR TITLE
feat: native window webview zoom rust-JS API

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2659,6 +2659,7 @@ dependencies = [
 name = "phoenix-code-ide"
 version = "3.2.15"
 dependencies = [
+ "objc",
  "once_cell",
  "percent-encoding",
  "regex",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2668,6 +2668,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-fs-extra",
  "tauri-plugin-window-state",
+ "webkit2gtk",
  "winapi",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,12 +18,14 @@ serde_json = "1.0"
 once_cell = "1.19.0"
 percent-encoding = "2.3"
 regex = "1.10.2"
-webkit2gtk = "0.18" # if tauri build fails, make sure to match this version to what we have in tauri
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.4", features = [ "cli", "api-all", "updater", "devtools", "linux-protocol-headers"] }
 winapi = { version = "0.3", features = ["fileapi"] }
 tauri-plugin-fs-extra = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+webkit2gtk = "0.18" # if tauri build fails, make sure to match this version to what we have in tauri
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,9 @@ tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-works
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = "0.18" # if tauri build fails, make sure to match this version to what we have in tauri
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2"
+
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 once_cell = "1.19.0"
 percent-encoding = "2.3"
 regex = "1.10.2"
+webkit2gtk = "0.18" # if tauri build fails, make sure to match this version to what we have in tauri
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.4", features = [ "cli", "api-all", "updater", "devtools", "linux-protocol-headers"] }
 winapi = { version = "0.3", features = ["fileapi"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,10 @@ use std::process::Command;
 #[cfg(target_os = "linux")]
 extern crate webkit2gtk;
 
+#[cfg(target_os = "macos")]
+#[macro_use]
+extern crate objc;
+
 use regex::Regex;
 extern crate percent_encoding;
 use tauri::http::ResponseBuilder;


### PR DESCRIPTION
After this , call in windows, linux and mac platforms for webview zoom
```js
     await __TAURI__.tauri.invoke("zoom_window", {scaleFactor:1.2});
```

Fixes: https://github.com/phcode-dev/phoenix/issues/1168

reference: https://docs.rs/tauri/latest/tauri/window/struct.Window.html