### PR TITLE
build: add media codecs in linux

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -106,7 +106,7 @@
                 "depends": []
             },
             "appimage": {
-                "bundleMediaFramework": false
+                "bundleMediaFramework": true
             },
             "externalBin": [
                 "phnode"


### PR DESCRIPTION
reinstating media codes as live previewing video is a workflow that the user would expect to be working. So a 2 second load pause for media libraries on click of video is acceptable.

We will remove all videos in phoenix desktop linnux builds in new project window and default project