### PR TITLE
fix: prod release name is always phoenix code

### DIFF
--- a/src-build/constants.js
+++ b/src-build/constants.js
@@ -3,7 +3,7 @@ export const PRODUCT_NAME_SUFFIX_FOR_STAGE = {
     // and brackets.config.staging.json. The product name suffix corresponding to each stage are values.
     dev : "Experimental Build",
     stage: "Pre-release",
-    production: "Beta" // Change to empty if we are out of beta/alpha/rc . Prod has no suffix
+    production: "" //  Prod has no suffix. !!!DO NOT use any beta/alpha/rc etc here in name as it will nuke update!!!
 };
 
 export const BUNDLE_IDENTIFIER_FOR_STAGE = {


### PR DESCRIPTION
Tauri uses the name to determine install/appdata folder, not just the id. So we will not be able to updrage the prod builds if we suffix names like beta/rc etc. That has to be done within phcode codebase app_name directly.