### PR TITLE
feat: add support for getting copied files from clipboard

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -559,6 +559,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-files"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc2120eaf094b70a9c58bd1f8bb908cb74fbfe0c9793314567f7f8cea0be383"
+dependencies = [
+ "clipboard-win",
+ "gtk",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "urlencoding",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,8 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "phoenix-code-ide"
-version = "3.2.17"
+version = "3.2.18"
 dependencies = [
+ "clipboard-files",
  "fix-path-env",
  "gtk",
  "objc",
@@ -4315,6 +4330,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 once_cell = "1.19.0"
 percent-encoding = "2.3"
 regex = "1.10.2"
+clipboard-files = "0.1.1"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.4", features = [ "cli", "api-all", "updater", "devtools", "linux-protocol-headers"] }
 winapi = { version = "0.3", features = ["fileapi"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,6 +21,8 @@ extern crate webkit2gtk;
 #[macro_use]
 extern crate objc;
 
+use clipboard_files;
+
 use regex::Regex;
 extern crate percent_encoding;
 use tauri::http::ResponseBuilder;
@@ -50,6 +52,18 @@ fn _get_windows_drives() -> Option<Vec<char>> {
 #[tauri::command]
 fn _rename_path(old_path: &str, new_path: &str) -> Result<(), String> {
     platform::rename_path(old_path, new_path)
+}
+
+#[tauri::command]
+fn _get_clipboard_files() -> Option<Vec<String>> {
+    match clipboard_files::read() {
+        Ok(paths) => Some(
+            paths.into_iter()
+                .map(|path| path.to_string_lossy().into_owned())
+                .collect()
+        ),
+        Err(_) => None,
+    }
 }
 
 static mut DEVTOOLS_LOADED:bool = false;
@@ -209,7 +223,7 @@ fn main() {
         .on_window_event(|event| process_window_event(&event))
         .invoke_handler(tauri::generate_handler![
             toggle_devtools, console_log, console_error,
-            _get_windows_drives, _rename_path, show_in_folder, zoom_window])
+            _get_windows_drives, _rename_path, show_in_folder, zoom_window, _get_clipboard_files])
         .setup(|app| {
             init::init_app(app);
             #[cfg(target_os = "linux")]


### PR DESCRIPTION
`window.__TAURI__.tauri.invoke('_get_clipboard_files')`  
returns and array of file paths if file(s) have been copied to clipboard
else returns null