### PR TITLE
fix: disable tauri file drop as it disables browser drag-drop

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -326,7 +326,8 @@
                 "title": "Phoenix Code Experimental Build",
                 "width": 1366,
                 "minWidth": 800,
-                "acceptFirstMouse": true
+                "acceptFirstMouse": true,
+                "fileDropEnabled": false
             }
         ]
     }


### PR DESCRIPTION
When we enable the tauri feature to enable drop files in tauri  window, it creeates the following problems
1. in windows browser drag drop events are disabled completely. This means that user cannot move files in files panel or move code with drag drop which is a critical in-editor workflow break.
2. In mac too, drag events work, but browser drop events are never received causing an evn greater inconsistency.
3. in linux most features work with no issues noted

So, in favor of in editor workflows, users can no-longer drop files from windows explorer/os finder into phoenix app to open the file. Users have to use `file menu>open` to open a file or folder. or `right click and use open with phoenix code` in future till tauri fixes this issue at their end.

start reference:
https://github.com/tauri-apps/tauri/issues/2768