### PR TITLE
ci: increase release build gen timeout to 60 mins

### DIFF
--- a/.github/workflows/tauri-build-dev.yml
+++ b/.github/workflows/tauri-build-dev.yml
@@ -72,7 +72,7 @@ jobs:
     needs: [create-release, build-mac-m1-node-modules]
     permissions:
       contents: write
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tauri-build-prod.yml
+++ b/.github/workflows/tauri-build-prod.yml
@@ -72,7 +72,7 @@ jobs:
     needs: [create-release, build-mac-m1-node-modules]
     permissions:
       contents: write
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tauri-build-staging.yml
+++ b/.github/workflows/tauri-build-staging.yml
@@ -72,7 +72,7 @@ jobs:
     needs: [create-release, build-mac-m1-node-modules]
     permissions:
       contents: write
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
cutting it too close.
Eg: https://github.com/phcode-dev/phoenix-desktop/actions/runs/7721463216/job/21048101258