### PR TITLE
feat: adding support for free m1 runner in devo

### DIFF
--- a/.github/workflows/tauri-build-staging.yml
+++ b/.github/workflows/tauri-build-staging.yml
@@ -43,7 +43,7 @@ jobs:
     permissions:
       contents: write
     timeout-minutes: 15
-    runs-on: macos-latest-xlarge
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - name: macos hardware info


### PR DESCRIPTION
### What kind of change does this PR introduce?
adding support for free m1 runner in devo