### PR TITLE
fix: linux open url with firefox usind xdmg

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-code-ide"
-version = "3.3.1"
+version = "3.3.2"
 dependencies = [
  "clipboard-files",
  "fix-path-env",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ windows_subsystem = "windows"
 )]
 use std::env;
 
+#[cfg(not(target_os = "linux"))]
 use webbrowser;
 
 use tauri::{Manager};
@@ -183,12 +184,23 @@ fn zoom_window(window: tauri::Window, scale_factor: f64) {
 
 #[tauri::command]
 fn open_url_in_browser(url: String) -> Result<(), String> {
-    // Attempt to open the URL in the default web browser
-    if webbrowser::open(&url).is_ok() {
-        Ok(())
-    } else {
-        Err("Failed to open URL in the browser".into())
+    #[cfg(target_os = "linux")]
+    {
+        // Use xdg-open for Linux
+        Command::new("xdg-open")
+            .arg(&url)
+            .spawn()
+            .map_err(|err| format!("Failed to open URL on Linux: {}", err))?;
     }
+
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    {
+        // Use the webbrowser crate for Windows and Mac
+        webbrowser::open(&url)
+            .map_err(|err| format!("Failed to open URL in the browser: {}", err))?;
+    }
+
+    Ok(())
 }
 
 fn process_window_event(event: &GlobalWindowEvent) {


### PR DESCRIPTION
it appears that `webbrowser` crate and tauri api doenst open the url in prod app image, if firefox is set as the default browser.
()Maybe tauri is using `webbrowser` create inernally? 

Anyways moved to `xdg-open` for linux.