### PR TITLE
build: add --runVerify cli command to see if app load success

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-code-ide"
-version = "3.3.2"
+version = "3.3.4"
 dependencies = [
  "clipboard-files",
  "fix-path-env",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -245,6 +245,11 @@ fn get_mac_deep_link_requests() -> Vec<String> {
 }
 
 fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.contains(&"--runVerify".to_string()) {
+        // Mainly used by linux installer to see if the app loaded successfully with all libs
+        std::process::exit(0);
+    }
 
     #[cfg(target_os = "macos")]{
         tauri_plugin_deep_link::prepare("io.phcode");


### PR DESCRIPTION
`phcode --runVerify` will exit with code 0 if run success without launching any ui.
Helpful to be used by linux installer to see if the app loaded successfully with all libs