### PR TITLE
refactor: remove unused open url in browser api

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1643,15 +1643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "html5ever"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,22 +1944,6 @@ dependencies = [
  "log",
  "thiserror",
  "walkdir",
-]
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys",
- "log",
- "thiserror",
- "walkdir",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2785,7 +2760,6 @@ dependencies = [
  "tauri-plugin-fs-extra",
  "tauri-plugin-single-instance",
  "tauri-plugin-window-state",
- "webbrowser",
  "webkit2gtk",
  "winapi",
 ]
@@ -3760,7 +3734,7 @@ dependencies = [
  "gtk",
  "image",
  "instant",
- "jni 0.20.0",
+ "jni",
  "lazy_static",
  "libc",
  "log",
@@ -4679,23 +4653,6 @@ checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webbrowser"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b2391658b02c27719fc5a0a73d6e696285138e8b12fba9d4baa70451023c71"
-dependencies = [
- "core-foundation",
- "home",
- "jni 0.21.1",
- "log",
- "ndk-context",
- "objc",
- "raw-window-handle",
- "url",
- "web-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,6 @@ once_cell = "1.19.0"
 percent-encoding = "2.3"
 regex = "1.10.3"
 clipboard-files = "0.1.1"
-webbrowser = "0.8.12"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.4", features = [ "updater", "cli", "api-all", "devtools", "linux-protocol-headers"] }
 winapi = { version = "0.3", features = ["fileapi"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,9 +4,6 @@ windows_subsystem = "windows"
 )]
 use std::env;
 
-#[cfg(not(target_os = "linux"))]
-use webbrowser;
-
 use tauri::{Manager};
 use std::path::PathBuf;
 
@@ -182,28 +179,6 @@ fn zoom_window(window: tauri::Window, scale_factor: f64) {
       });
 }
 
-#[tauri::command]
-fn open_url_in_browser(url: String) -> Result<(), String> {
-    #[cfg(target_os = "linux")]
-    {
-        // Use xdg-open for Linux
-        Command::new("xdg-open")
-            .arg(&url)
-            .current_dir("/tmp")
-            .spawn()
-            .map_err(|err| format!("Failed to open URL on Linux: {}", err))?;
-    }
-
-    #[cfg(any(target_os = "windows", target_os = "macos"))]
-    {
-        // Use the webbrowser crate for Windows and Mac
-        webbrowser::open(&url)
-            .map_err(|err| format!("Failed to open URL in the browser: {}", err))?;
-    }
-
-    Ok(())
-}
-
 fn process_window_event(event: &GlobalWindowEvent) {
     if let tauri::WindowEvent::CloseRequested { .. } = event.event() {
         // this does nothing and is here if in future you need to persist something on window close.
@@ -326,7 +301,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             get_mac_deep_link_requests,
             toggle_devtools, console_log, console_error, _get_commandline_args, get_current_working_dir,
-            _get_window_labels, open_url_in_browser,
+            _get_window_labels,
             _get_windows_drives, _rename_path, show_in_folder, zoom_window, _get_clipboard_files])
         .setup(|app| {
             init::init_app(app);


### PR DESCRIPTION
We needed `open_url_in_browser` api in linux as linux was not linuxing with app images. Since we are deprecating appimages and moving to native linux binaries/bash installers, this is no longer needed, neither did it work eventually.