### PR TITLE
fix: update timestamp url to global sign

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -144,7 +144,7 @@
             "windows": {
                 "certificateThumbprint": "AB7D19C00251C1E412594A28DC79D201AAEF50D0",
                 "digestAlgorithm": "sha256",
-                "timestampUrl": "http://timestamp.comodoca.com",
+                "timestampUrl": "http://timestamp.globalsign.com/tsa/advanced",
                 "nsis": {
                     "displayLanguageSelector": true,
                     "license": "./license/agpl",


### PR DESCRIPTION
### What kind of change does this PR introduce?
update the timestamp URL to global sign and see if it fixes warning in edge