### PR TITLE
chire: add recursive-rm-unix private command

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -105,6 +105,16 @@
                                 "validator": "\\S*"
                             }
                         ]
+                    },
+                    {
+                        "name": "recursive-rm-unix",
+                        "cmd": "rm",
+                        "args": [
+                            "-rf",
+                            {
+                                "validator": "\\S*"
+                            }
+                        ]
                     }
                 ]
             }


### PR DESCRIPTION
Mainly to be used by mac update installer, where we cant rely on tauri apis or node to be present as the underlying binaries are being rewritten.