### PR TITLE
feat: add untar-unix command

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -107,6 +107,24 @@
                         ]
                     },
                     {
+                        "name": "untar-unix",
+                        "cmd": "tar",
+                        "args": [
+                            {
+                                "validator": "\\S*"
+                            },
+                            {
+                                "validator": "\\S*"
+                            },
+                            {
+                                "validator": "\\S*"
+                            },
+                            {
+                                "validator": "\\S*"
+                            }
+                        ]
+                    },
+                    {
                         "name": "recursive-rm-unix",
                         "cmd": "rm",
                         "args": [


### PR DESCRIPTION
This is needed for mac auto updates as the earlier update flow used to extract the file at node side and then copy it on exit. This created a problem where the downloaded app(which is yet to be installed) would register into macs `open with` apps and show up in finder `open with` as 2 entries for phoneix app.