### PR TITLE
fix: extra / is path when show in os files is done

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -173,7 +173,7 @@ fn show_in_folder(path: String) {
                 .arg("--type=method_call")
                 .arg("/org/freedesktop/FileManager1")
                 .arg("org.freedesktop.FileManager1.ShowItems")
-                .arg(format!("array:string:file:///{}", path))
+                .arg(format!("array:string:file://{}", path))
                 .arg("string:\"\"")
                 .spawn()
                 .unwrap();


### PR DESCRIPTION
And extra `/` was being seen in the file path bar in Linux. See image below:
![image](https://github.com/phcode-dev/phoenix-desktop/assets/5336369/839d223e-8b74-4f4b-b4b2-9c6079fd4dfa)
