### PR TITLE
Revert "chore(deps): update dependency macos to v14"

### DIFF
--- a/.github/workflows/desktop-mac-test-pull.yml
+++ b/.github/workflows/desktop-mac-test-pull.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   test-desktop-mac:
-    runs-on: macos-14
+    runs-on: macos-12
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This reverts commit 703ff1e273ef9242187e70d37a40ffd1e63b5193.

Revert "chore(deps): update dependency macos to v14"