### PR TITLE
chore: add chrome_os play store link

### DIFF
--- a/.github/workflows/updateNotification.js
+++ b/.github/workflows/updateNotification.js
@@ -183,7 +183,8 @@ export default async function printStuff({github, context, githubWorkspaceRoot})
             "phcode.io.DownloadURL": {
                 "windows_x64": windowsDownloadURL,
                 "mac_m1": macM1DownloadURL,
-                "mac_intel": macIntelDownloadURL
+                "mac_intel": macIntelDownloadURL,
+                "chrome_os": "https://play.google.com/store/apps/details?id=prod.phcode.twa"
             }
         };
         installJSON = JSON.stringify(installJSON, null, 4);


### PR DESCRIPTION
Continuation of https://github.com/phcode-dev/phoenix-desktop/pull/505

This updates github actions to also include chrome app link on new release. the other pr was for current release manually added.