### PR TITLE
fix: linux installer was failing in arch

### DIFF
--- a/docs/linux/installer.sh
+++ b/docs/linux/installer.sh
@@ -263,8 +263,7 @@ install_dependencies() {
       ;;
     arch|manjaro)
       echo "Detected an Arch Linux based distribution."
-      sudo pacman -Syu
-      sudo pacman -S webkit2gtk gtk3
+      yes | sudo pacman -S webkit2gtk gtk3
       ;;
     *)
       echo "Unsupported distribution. Please manually install the required dependencies."


### PR DESCRIPTION
### What kind of change does this PR introduce?
The install script failed when the user copied and pasted the script from the website to the terminal and ran in the shell.
This pull request fixes it