### PR TITLE
fix: long package names in windows open with options

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phoenix-code-ide"
 version = "3.9.4"
-description = "Phoenix is a modern open-source IDE for the web, built for the browser."
+description = "Phoenix Code"
 authors = ["arun@core.ai, charly@core.ai"]
 license = "GNU AGPL 3.0"
 repository = "https://github.com/phcode-dev/phoenix-desktop"


### PR DESCRIPTION
https://github.com/phcode-dev/phoenix-desktop/pull/537 didnt work. so this 