### PR TITLE
build: remove dmg generation from releases <do not merge>

### DIFF
--- a/.github/workflows/tauri-build-dev.yml
+++ b/.github/workflows/tauri-build-dev.yml
@@ -326,6 +326,110 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+  copyMacAppWithVersion:
+    name: Copy Mac .app Files With Version
+    needs: [ create-release, build-tauri, build-linux-bins ]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Recompute or ensure we have PACKAGE_VERSION and GIT_TAG_NAME in the env
+      - name: get version
+        run: |
+          echo "PACKAGE_VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+          echo "GIT_TAG_NAME=prod-app-v$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+
+      #
+      # 1) Download the x64 .app.tar.gz from the existing draft release
+      #
+      - name: Download x64 Mac asset
+        id: download_x64
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const { data: release } = await github.rest.repos.getRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id:  parseInt("${{ needs.create-release.outputs.release_id }}", 10)
+            });
+            const asset = release.assets.find(a => a.name === "Phoenix.Code.Experimental.Build_x64.app.tar.gz");
+            if (!asset) {
+              core.setFailed("Could not find 'Phoenix.Code.Experimental.Build_x64.app.tar.gz' in draft release assets.");
+              return;
+            }
+            // Download the asset
+            const download = await github.rest.repos.getReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              asset_id: asset.id,
+              headers: {
+                accept: "application/octet-stream"
+              }
+            });
+            fs.writeFileSync("Phoenix.Code.Experimental.Build_x64.app.tar.gz", Buffer.from(download.data));
+
+      #
+      # 2) Download the aarch64 .app.tar.gz from the existing draft release
+      #
+      - name: Download aarch64 Mac asset
+        id: download_aarch64
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const { data: release } = await github.rest.repos.getRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: parseInt("${{ needs.create-release.outputs.release_id }}", 10)
+            });
+            const asset = release.assets.find(a => a.name === "Phoenix.Code.Experimental.Build_aarch64.app.tar.gz");
+            if (!asset) {
+              core.setFailed("Could not find 'Phoenix.Code.Experimental.Build_aarch64.app.tar.gz' in draft release assets.");
+              return;
+            }
+            // Download the asset
+            const download = await github.rest.repos.getReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              asset_id: asset.id,
+              headers: {
+                accept: "application/octet-stream"
+              }
+            });
+            fs.writeFileSync("Phoenix.Code.Experimental.Build_aarch64.app.tar.gz", Buffer.from(download.data));
+
+      #
+      # 3) Rename each asset with the version appended
+      #
+      - name: Rename Mac assets to include version
+        run: |
+          echo "Renaming x64 Mac app..."
+          mv Phoenix.Code.Experimental.Build_x64.app.tar.gz "Phoenix.Code.Experimental.Build_x64_${PACKAGE_VERSION}_intel.app.tar.gz"
+
+          echo "Renaming aarch64 Mac app..."
+          mv Phoenix.Code.Experimental.Build_aarch64.app.tar.gz "Phoenix.Code.Experimental.Build_aarch64_${PACKAGE_VERSION}_M1.app.tar.gz"
+
+          echo "Final check of renamed files:"
+          ls -lh
+
+      #
+      # 4) Re-upload them to the draft release with new filenames. This is needed for download from web workflows
+      #
+      - name: Upload renamed Mac app tarballs to draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          release_id: ${{ needs.create-release.outputs.release_id }}
+          draft: true
+          tag_name: ${{ env.GIT_TAG_NAME }}
+          files: |
+            Phoenix.Code.Experimental.Build_x64_${{ env.PACKAGE_VERSION }}_intel.app.tar.gz
+            Phoenix.Code.Experimental.Build_aarch64_${{ env.PACKAGE_VERSION }}_M1.app.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-release:
     permissions:
       contents: write

--- a/.github/workflows/tauri-build-prod.yml
+++ b/.github/workflows/tauri-build-prod.yml
@@ -372,6 +372,110 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+  copyMacAppWithVersion:
+    name: Copy Mac .app Files With Version
+    needs: [ create-release, build-tauri, build-linux-bins ]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Recompute or ensure we have PACKAGE_VERSION and GIT_TAG_NAME in the env
+      - name: get version
+        run: |
+          echo "PACKAGE_VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+          echo "GIT_TAG_NAME=prod-app-v$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+
+      #
+      # 1) Download the x64 .app.tar.gz from the existing draft release
+      #
+      - name: Download x64 Mac asset
+        id: download_x64
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const { data: release } = await github.rest.repos.getRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id:  parseInt("${{ needs.create-release.outputs.release_id }}", 10)
+            });
+            const asset = release.assets.find(a => a.name === "Phoenix.Code_x64.app.tar.gz");
+            if (!asset) {
+              core.setFailed("Could not find 'Phoenix.Code_x64.app.tar.gz' in draft release assets.");
+              return;
+            }
+            // Download the asset
+            const download = await github.rest.repos.getReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              asset_id: asset.id,
+              headers: {
+                accept: "application/octet-stream"
+              }
+            });
+            fs.writeFileSync("Phoenix.Code_x64.app.tar.gz", Buffer.from(download.data));
+
+      #
+      # 2) Download the aarch64 .app.tar.gz from the existing draft release
+      #
+      - name: Download aarch64 Mac asset
+        id: download_aarch64
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const { data: release } = await github.rest.repos.getRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: parseInt("${{ needs.create-release.outputs.release_id }}", 10)
+            });
+            const asset = release.assets.find(a => a.name === "Phoenix.Code_aarch64.app.tar.gz");
+            if (!asset) {
+              core.setFailed("Could not find 'Phoenix.Code_aarch64.app.tar.gz' in draft release assets.");
+              return;
+            }
+            // Download the asset
+            const download = await github.rest.repos.getReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              asset_id: asset.id,
+              headers: {
+                accept: "application/octet-stream"
+              }
+            });
+            fs.writeFileSync("Phoenix.Code_aarch64.app.tar.gz", Buffer.from(download.data));
+
+      #
+      # 3) Rename each asset with the version appended
+      #
+      - name: Rename Mac assets to include version
+        run: |
+          echo "Renaming x64 Mac app..."
+          mv Phoenix.Code_x64.app.tar.gz "Phoenix.Code_x64_${PACKAGE_VERSION}_intel.app.tar.gz"
+
+          echo "Renaming aarch64 Mac app..."
+          mv Phoenix.Code_aarch64.app.tar.gz "Phoenix.Code_aarch64_${PACKAGE_VERSION}_M1.app.tar.gz"
+
+          echo "Final check of renamed files:"
+          ls -lh
+
+      #
+      # 4) Re-upload them to the draft release with new filenames. This is needed for download from web workflows
+      #
+      - name: Upload renamed Mac app tarballs to draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          release_id: ${{ needs.create-release.outputs.release_id }}
+          draft: true
+          tag_name: ${{ env.GIT_TAG_NAME }}
+          files: |
+            Phoenix.Code_x64_${{ env.PACKAGE_VERSION }}_intel.app.tar.gz
+            Phoenix.Code_aarch64_${{ env.PACKAGE_VERSION }}_M1.app.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-release:
     permissions:
       contents: write

--- a/.github/workflows/updateNotification.js
+++ b/.github/workflows/updateNotification.js
@@ -83,10 +83,10 @@ async function _getLatestJson(releaseAssets) {
 
 // "Phoenix.Code.Experimental.Build_3.4.2_x64-setup.exe"
 const WINDOWS_X64_NAME_SUFFIX = "_x64-setup.exe";
-// "Phoenix.Code.Experimental.Build_3.4.2_x64.dmg"
-const MAC_INTEL_NAME_SUFFIX = "_x64.dmg";
-// "Phoenix.Code.Experimental.Build_3.4.2_aarch64.dmg"
-const MAC_M1_NAME_SUFFIX = "_aarch64.dmg";
+// "Phoenix.Code.Experimental.Build_3.4.2_intel.app.tar.gz"
+const MAC_INTEL_NAME_SUFFIX = "_intel.app.tar.gz";
+// "Phoenix.Code.Experimental.Build_3.4.2_M1.app.tar.gz"
+const MAC_M1_NAME_SUFFIX = "_M1.app.tar.gz";
 function _getDownloadURLByNameSuffix(releaseAssets, suffix) {
     for(let releaseAsset of releaseAssets) {
         if(releaseAsset.name.endsWith(suffix)){

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -201,7 +201,6 @@
                 "appimage",
                 "nsis",
                 "app",
-                "dmg",
                 "updater"
             ],
             "windows": {


### PR DESCRIPTION
This PR deprecates DMG generation as there is frequent DMG build failures. Since we dont really use DMG for updates, we can saely deprecate it. Merging this wr would ideally do the thing, and should be fully self contained. Do this if we need to depreacte dmg in the future.