### PR TITLE
fix: restore custom window position/size persistence across restarts

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -381,15 +381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,7 +3427,6 @@ dependencies = [
  "tauri-plugin-deep-link",
  "tauri-plugin-fs-extra",
  "tauri-plugin-single-instance",
- "tauri-plugin-window-state",
  "tokio",
  "trash",
  "webbrowser",
@@ -4826,20 +4816,6 @@ dependencies = [
  "thiserror",
  "windows-sys 0.52.0",
  "zbus",
-]
-
-[[package]]
-name = "tauri-plugin-window-state"
-version = "0.1.1"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#184f4edbbcfed8f8c057a15e02318e0ddcaab132"
-dependencies = [
- "bincode",
- "bitflags 2.5.0",
- "log",
- "serde",
- "serde_json",
- "tauri",
- "thiserror",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,6 @@ tauri = { version = "1.6.2", features = [ "updater", "cli", "api-all", "devtools
 winapi = { version = "0.3.9", features = ["fileapi", "wingdi", "winuser", "windef"] }
 png = "0.17"
 tauri-plugin-fs-extra = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
-tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 keyring = "2.3.3"

--- a/src-tauri/src/boot_config.rs
+++ b/src-tauri/src/boot_config.rs
@@ -15,7 +15,12 @@ pub static APP_CONSTANTS: OnceCell<AppConstants> = OnceCell::new();
 
 #[derive(Serialize)]
 pub struct BootConfig {
-    pub version: u32
+    pub version: u32,
+    pub last_window_x: i32,
+    pub last_window_y: i32,
+    pub last_window_width: u32,
+    pub last_window_height: u32,
+    pub last_window_maximized: bool,
 }
 static BOOT_CONFIG_FILE_NAME: &'static str = "boot_config.json";
 
@@ -30,11 +35,36 @@ fn _set_boot_config(boot_config: &mut BootConfig, value: &Value) {
         Some(value) => value as u32,
         None => 0
     };
+    boot_config.last_window_x = match value["last_window_x"].as_i64() {
+        Some(v) => v as i32,
+        None => 0
+    };
+    boot_config.last_window_y = match value["last_window_y"].as_i64() {
+        Some(v) => v as i32,
+        None => 0
+    };
+    boot_config.last_window_width = match value["last_window_width"].as_u64() {
+        Some(v) => v as u32,
+        None => 0
+    };
+    boot_config.last_window_height = match value["last_window_height"].as_u64() {
+        Some(v) => v as u32,
+        None => 0
+    };
+    boot_config.last_window_maximized = match value["last_window_maximized"].as_bool() {
+        Some(v) => v,
+        None => false
+    };
 }
 
 pub fn read_boot_config() -> BootConfig {
     let mut boot_config = BootConfig {
-        version: 1
+        version: 1,
+        last_window_x: 0,
+        last_window_y: 0,
+        last_window_width: 0,
+        last_window_height: 0,
+        last_window_maximized: false,
     };
     if let Some(app_constants) = APP_CONSTANTS.get() {
         let boot_config_file_path = get_boot_config_file_path(&app_constants.app_local_data_dir);
@@ -62,8 +92,13 @@ fn _write_boot_config(boot_config: &BootConfig) {
 }
 
 // WARNING: If there are multiple windows, this will be called on each window close.
-pub fn write_boot_config(version: u32) {
+pub fn write_boot_config(version: u32, x: i32, y: i32, width: u32, height: u32, maximized: bool) {
     _write_boot_config(&BootConfig {
-         version
-     })
+        version,
+        last_window_x: x,
+        last_window_y: y,
+        last_window_width: width,
+        last_window_height: height,
+        last_window_maximized: maximized,
+    })
 }

--- a/src-tauri/src/init.rs
+++ b/src-tauri/src/init.rs
@@ -1,7 +1,118 @@
 use crate::utilities::ensure_dir_exists;
-use crate::boot_config::read_boot_config;
+use crate::boot_config::{read_boot_config, BootConfig};
 use crate::boot_config::APP_CONSTANTS;
 use crate::boot_config::AppConstants;
+use tauri::Manager;
+
+/// Returns true if the point (x, y) falls within any of the available monitors.
+fn is_position_on_any_monitor(x: i32, y: i32, monitors: &[tauri::Monitor]) -> bool {
+    for monitor in monitors {
+        let mon_pos = monitor.position();
+        let mon_size = monitor.size();
+        if x >= mon_pos.x
+            && x < mon_pos.x + mon_size.width as i32
+            && y >= mon_pos.y
+            && y < mon_pos.y + mon_size.height as i32
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Restores the main window's position, size, and maximized state from boot_config.
+/// This is intentionally fault-tolerant: any failure is logged and silently ignored
+/// so the app always starts, even with a corrupted or missing config.
+fn restore_window_state(app: &mut tauri::App, boot_config: &BootConfig) {
+    let win = match app.get_window("main") {
+        Some(w) => w,
+        None => {
+            eprintln!("restore_window_state: could not find main window");
+            return;
+        }
+    };
+
+    if boot_config.last_window_maximized {
+        if let Err(e) = win.maximize() {
+            eprintln!("restore_window_state: failed to maximize window: {}", e);
+        }
+        return;
+    }
+
+    let saved_w = boot_config.last_window_width;
+    let saved_h = boot_config.last_window_height;
+
+    if saved_w > 0 && saved_h > 0 {
+        // If the saved size exceeds the current screen, maximize instead of clamping.
+        // Clamping to raw pixels would still ignore taskbar/dock; maximizing lets the
+        // OS place the window correctly within the usable work area.
+        let fits_screen = match win.current_monitor() {
+            Ok(Some(monitor)) => {
+                let screen = monitor.size();
+                saved_w <= screen.width && saved_h <= screen.height
+            }
+            _ => true, // can't determine screen size, assume it fits
+        };
+
+        if !fits_screen {
+            if let Err(e) = win.maximize() {
+                eprintln!("restore_window_state: failed to maximize for oversized saved state: {}", e);
+            }
+        } else {
+            if let Err(e) = win.set_size(tauri::Size::Physical(tauri::PhysicalSize {
+                width: saved_w,
+                height: saved_h,
+            })) {
+                eprintln!("restore_window_state: failed to set window size: {}", e);
+            }
+
+            // Restore position only if the saved position is on a currently connected monitor
+            let saved_x = boot_config.last_window_x;
+            let saved_y = boot_config.last_window_y;
+            match win.available_monitors() {
+                Ok(monitors) => {
+                    if is_position_on_any_monitor(saved_x, saved_y, &monitors) {
+                        if let Err(e) = win.set_position(tauri::Position::Physical(
+                            tauri::PhysicalPosition { x: saved_x, y: saved_y },
+                        )) {
+                            eprintln!("restore_window_state: failed to set window position: {}", e);
+                        }
+                    }
+                    // else: monitor disconnected, let the OS place the window
+                }
+                Err(e) => {
+                    eprintln!("restore_window_state: failed to list monitors: {}", e);
+                    // Cannot validate position; skip position restore, size is already set
+                }
+            }
+        }
+    } else {
+        // First launch (no saved state) - use preferred size or maximize if screen is too small
+        match win.current_monitor() {
+            Ok(Some(monitor)) => {
+                let screen = monitor.size();
+                if screen.width > 1366 && screen.height > 900 {
+                    if let Err(e) = win.set_size(tauri::Size::Physical(tauri::PhysicalSize {
+                        width: 1366,
+                        height: 900,
+                    })) {
+                        eprintln!("restore_window_state: failed to set default size: {}", e);
+                    }
+                } else {
+                    if let Err(e) = win.maximize() {
+                        eprintln!("restore_window_state: failed to maximize on small screen: {}", e);
+                    }
+                }
+            }
+            Ok(None) => {
+                eprintln!("restore_window_state: no current monitor detected");
+            }
+            Err(e) => {
+                eprintln!("restore_window_state: failed to get current monitor: {}", e);
+            }
+        }
+    }
+}
 
 pub fn init_app(app: &mut tauri::App) {
     let config = app.config().clone();
@@ -19,9 +130,10 @@ pub fn init_app(app: &mut tauri::App) {
             println!("Bundle ID is {}", app_constants.tauri_config.tauri.bundle.identifier);
         }
         ensure_dir_exists(&app_constants.app_local_data_dir);
-        read_boot_config();
+        let boot_config = read_boot_config();
         #[cfg(debug_assertions)]{
-            println!("Bootconfig version is {}", read_boot_config().version);
+            println!("Bootconfig version is {}", boot_config.version);
         }
+        restore_window_state(app, &boot_config);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -47,7 +47,6 @@ mod boot_config;
 use trash;
 
 mod platform;
-use tauri_plugin_window_state::StateFlags;
 
 use keyring::Entry;
 use whoami;
@@ -352,8 +351,20 @@ fn process_window_event(event: &GlobalWindowEvent, trust_state: &State<WindowAes
             println!("AES trust removed for closing window: {}", window_label);
         }
 
-        // this does nothing and is here if in future you need to persist something on window close.
-        boot_config::write_boot_config(1);
+        // Save main window position/size so it can be restored on next launch
+        if window_label == "main" {
+            let window = event.window();
+            let maximized = window.is_maximized().unwrap_or(false);
+            let (x, y) = match window.outer_position() {
+                Ok(pos) => (pos.x, pos.y),
+                Err(_) => (0, 0),
+            };
+            let (width, height) = match window.outer_size() {
+                Ok(size) => (size.width, size.height),
+                Err(_) => (0, 0),
+            };
+            boot_config::write_boot_config(1, x, y, width, height, maximized);
+        }
     }
 }
 
@@ -813,7 +824,6 @@ fn main() {
             Ok(response)
         })
         .plugin(tauri_plugin_fs_extra::init())
-        .plugin(tauri_plugin_window_state::Builder::default().with_state_flags(StateFlags::all() & !StateFlags::VISIBLE).build())
         .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
                     println!("{}, {argv:?}, {cwd}", app.package_info().name);
 


### PR DESCRIPTION
Replace non-functional tauri-plugin-window-state with a custom implementation that saves window x, y, width, height, and maximized state to boot_config.json on close and restores on launch.

- Add window state fields to BootConfig struct
- Add restore_window_state() with multi-monitor awareness: validates saved position against connected monitors, maximizes if saved size exceeds current screen, falls back to 1366x900 on first launch
- Save outer_size (not inner_size) to avoid progressive shrinking from title bar/border mismatch
- Remove tauri-plugin-window-state dependency and plugin registration

fixes: https://github.com/phcode-dev/phoenix/issues/1796
