### PR TITLE
fix(tauri): correct screenshot rect on Windows under DPI scaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix-code-ide",
-    "version": "5.1.8",
+    "version": "5.1.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix-code-ide",
-            "version": "5.1.8",
+            "version": "5.1.21",
             "hasInstallScript": true,
             "devDependencies": {
                 "@tauri-apps/cli": "1.6.3",

--- a/src-build/downloadNodeBinary.js
+++ b/src-build/downloadNodeBinary.js
@@ -187,7 +187,7 @@ function unzipFile(zipFilePath, extractPath) {
         }
 
         if (!zipEntry.isDirectory) {
-            zip.extractEntryTo(zipEntry.entryName, extractPath);
+            zip.extractEntryTo(zipEntry.entryName, extractPath, /*maintainEntryPath*/true, /*overwrite*/true);
         }
     });
 

--- a/src-electron/package-lock.json
+++ b/src-electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phoenix-code-electron-shell",
-  "version": "5.1.8",
+  "version": "5.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "phoenix-code-electron-shell",
-      "version": "5.1.8",
+      "version": "5.1.21",
       "dependencies": {
         "keytar": "^7.9.0"
       },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-code-ide"
-version = "5.1.4"
+version = "5.1.21"
 dependencies = [
  "aes-gcm",
  "backtrace",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -538,6 +538,11 @@ fn capture_page_windows(window: tauri::Window, rect: Option<CaptureRect>) -> Res
     };
     use winapi::shared::windef::{RECT, HGDIOBJ};
 
+    // GDI works in physical pixels, but the JS caller sends the rect in CSS pixels
+    // (scaled only by the webview zoom factor, not by the OS DPI). Convert by
+    // multiplying with the window's OS scale factor (1.25 at Windows 125% scaling).
+    let dpi_scale = window.scale_factor().unwrap_or(1.0);
+
     unsafe {
         let hwnd = window.hwnd().map_err(|e| e.to_string())?;
         let hwnd = hwnd.0 as winapi::shared::windef::HWND;
@@ -584,12 +589,13 @@ fn capture_page_windows(window: tauri::Window, rect: Option<CaptureRect>) -> Res
             chunk.swap(0, 2);
         }
 
-        // Extract the requested region (or full image)
+        // Extract the requested region (or full image). Convert the incoming
+        // CSS-pixel rect into physical pixels using the OS DPI scale factor.
         let (cap_x, cap_y, cap_w, cap_h) = if let Some(r) = &rect {
-            let x = (r.x as i32).max(0).min(full_width);
-            let y = (r.y as i32).max(0).min(full_height);
-            let w = (r.width as i32).min(full_width - x).max(0);
-            let h = (r.height as i32).min(full_height - y).max(0);
+            let x = ((r.x * dpi_scale).round() as i32).max(0).min(full_width);
+            let y = ((r.y * dpi_scale).round() as i32).max(0).min(full_height);
+            let w = ((r.width * dpi_scale).round() as i32).min(full_width - x).max(0);
+            let h = ((r.height * dpi_scale).round() as i32).min(full_height - y).max(0);
             (x, y, w, h)
         } else {
             (0, 0, full_width, full_height)


### PR DESCRIPTION
GDI APIs (GetClientRect, PrintWindow, GetDIBits) operate in physical
pixels for DPI-aware processes, but the JS caller sends the capture
rect in CSS pixels (scaled only by the webview zoom factor, not the
OS DPI). At Windows display scaling >100%, this produced screenshots
that were both shifted and undersized.

Multiply the incoming rect by window.scale_factor() (the OS DPI scale,
e.g. 1.25 at 125% scaling) before clamping to the physical client area.
macOS is unaffected because WKSnapshotConfiguration.setRect takes view
points, which map 1:1 to CSS pixels. Electron (Linux) is unaffected
because capturePage already accepts CSS-pixel rects.