### PR TITLE
fix: critical update banner for Windows <=5.2.0

### DIFF
--- a/docs/appNotifications/prod/de/banner.json
+++ b/docs/appNotifications/prod/de/banner.json
@@ -1,4 +1,10 @@
 {
+  "CRITICAL_WINDOWS_UPDATE_5_2_0": {
+    "DANGER_SHOW_ON_EVERY_BOOT": true,
+    "HTML_CONTENT": "<div style='display:flex;align-items:center;gap:10px;'><div><div style='font-weight:600;'>Kritisches Update erforderlich</div><div style='opacity:0.85;font-size:0.9em;'>Diese Version von Phoenix Code für Windows weist ein kritisches Stabilitätsproblem auf. Bitte laden Sie die neueste Version von phcode.io herunter und installieren Sie sie.</div></div><button class='btn primary' onclick=\"Phoenix.app.openURLInDefaultBrowser('https://phcode.io')\">Herunterladen</button></div>",
+    "FOR_VERSIONS": "<=5.2.0",
+    "PLATFORM": "win"
+  },
   "DESKTOP_APP_BANNER": {
     "DANGER_SHOW_ON_EVERY_BOOT" : false,
     "HTML_CONTENT": "<div><b>Wir stellen vor</b> Phoenix Code <b>Desktop-Apps</b> für Windows, Mac und Linux. <a class='notification_ack' href='https://phcode.io' _target='_blank'> Klicken Sie hier, um es jetzt zu erhalten!</a></div>",

--- a/docs/appNotifications/prod/fr/banner.json
+++ b/docs/appNotifications/prod/fr/banner.json
@@ -1,4 +1,10 @@
 {
+  "CRITICAL_WINDOWS_UPDATE_5_2_0": {
+    "DANGER_SHOW_ON_EVERY_BOOT": true,
+    "HTML_CONTENT": "<div style='display:flex;align-items:center;gap:10px;'><div><div style='font-weight:600;'>Mise à jour critique requise</div><div style='opacity:0.85;font-size:0.9em;'>Cette version de Phoenix Code pour Windows présente un problème de stabilité critique. Veuillez télécharger et installer la dernière version depuis phcode.io.</div></div><button class='btn primary' onclick=\"Phoenix.app.openURLInDefaultBrowser('https://phcode.io')\">Télécharger</button></div>",
+    "FOR_VERSIONS": "<=5.2.0",
+    "PLATFORM": "win"
+  },
   "DESKTOP_APP_BANNER": {
     "DANGER_SHOW_ON_EVERY_BOOT" : false,
     "HTML_CONTENT": "<div><b>Présentation</b> des <b>applications de bureau</b> de Phoenix Code pour Windows, Mac et Linux. <a class='notification_ack' href='https://phcode.io' _target='_blank'> Cliquez ici pour l'obtenir maintenant !</a></div>",

--- a/docs/appNotifications/prod/it/banner.json
+++ b/docs/appNotifications/prod/it/banner.json
@@ -1,4 +1,10 @@
 {
+  "CRITICAL_WINDOWS_UPDATE_5_2_0": {
+    "DANGER_SHOW_ON_EVERY_BOOT": true,
+    "HTML_CONTENT": "<div style='display:flex;align-items:center;gap:10px;'><div><div style='font-weight:600;'>Aggiornamento critico richiesto</div><div style='opacity:0.85;font-size:0.9em;'>Questa versione di Phoenix Code per Windows presenta un problema di stabilità critico. Scarica e installa l'ultima versione da phcode.io.</div></div><button class='btn primary' onclick=\"Phoenix.app.openURLInDefaultBrowser('https://phcode.io')\">Scarica</button></div>",
+    "FOR_VERSIONS": "<=5.2.0",
+    "PLATFORM": "win"
+  },
   "DESKTOP_APP_BANNER": {
     "DANGER_SHOW_ON_EVERY_BOOT" : false,
     "HTML_CONTENT": "<div><b>Presentazione</b> delle <b>app desktop</b> di Phoenix Code per Windows, Mac e Linux. <a class='notification_ack' href='https://phcode.io' _target='_blank'> Fai clic qui per ottenerlo ora!</a></div>",

--- a/docs/appNotifications/prod/ja/banner.json
+++ b/docs/appNotifications/prod/ja/banner.json
@@ -1,4 +1,10 @@
 {
+  "CRITICAL_WINDOWS_UPDATE_5_2_0": {
+    "DANGER_SHOW_ON_EVERY_BOOT": true,
+    "HTML_CONTENT": "<div style='display:flex;align-items:center;gap:10px;'><div><div style='font-weight:600;'>重要なアップデートが必要です</div><div style='opacity:0.85;font-size:0.9em;'>このバージョンの Windows 版 Phoenix Code には重大な安定性の問題があります。phcode.io から最新バージョンをダウンロードしてインストールしてください。</div></div><button class='btn primary' onclick=\"Phoenix.app.openURLInDefaultBrowser('https://phcode.io')\">ダウンロード</button></div>",
+    "FOR_VERSIONS": "<=5.2.0",
+    "PLATFORM": "win"
+  },
   "DESKTOP_APP_BANNER": {
     "DANGER_SHOW_ON_EVERY_BOOT" : false,
     "HTML_CONTENT": "<div>Windows、Mac、Linux 用の <b>Phoenix Code の<b>デスクトップ アプリ</b>を紹介</b>します。 <a class='notification_ack' href='https://phcode.io' _target='_blank'> ここをクリックして今すぐ入手してください。</a></div>",

--- a/docs/appNotifications/prod/ko/banner.json
+++ b/docs/appNotifications/prod/ko/banner.json
@@ -1,4 +1,10 @@
 {
+  "CRITICAL_WINDOWS_UPDATE_5_2_0": {
+    "DANGER_SHOW_ON_EVERY_BOOT": true,
+    "HTML_CONTENT": "<div style='display:flex;align-items:center;gap:10px;'><div><div style='font-weight:600;'>중요 업데이트가 필요합니다</div><div style='opacity:0.85;font-size:0.9em;'>이 버전의 Windows용 Phoenix Code에는 심각한 안정성 문제가 있습니다. phcode.io에서 최신 버전을 다운로드하여 설치하세요.</div></div><button class='btn primary' onclick=\"Phoenix.app.openURLInDefaultBrowser('https://phcode.io')\">다운로드</button></div>",
+    "FOR_VERSIONS": "<=5.2.0",
+    "PLATFORM": "win"
+  },
   "DESKTOP_APP_BANNER": {
     "DANGER_SHOW_ON_EVERY_BOOT" : false,
     "HTML_CONTENT": "<div>Windows, Mac 및 Linux용 <b>소개</b> Phoenix Code <b>데스크톱 앱</b>. <a class='notification_ack' href='https://phcode.io' _target='_blank'> 지금 다운로드하려면 여기를 클릭하세요!</a></div>",

--- a/docs/appNotifications/prod/pt-BR/banner.json
+++ b/docs/appNotifications/prod/pt-BR/banner.json
@@ -1,4 +1,10 @@
 {
+  "CRITICAL_WINDOWS_UPDATE_5_2_0": {
+    "DANGER_SHOW_ON_EVERY_BOOT": true,
+    "HTML_CONTENT": "<div style='display:flex;align-items:center;gap:10px;'><div><div style='font-weight:600;'>Atualização crítica necessária</div><div style='opacity:0.85;font-size:0.9em;'>Esta versão do Phoenix Code para Windows apresenta um problema crítico de estabilidade. Baixe e instale a versão mais recente em phcode.io.</div></div><button class='btn primary' onclick=\"Phoenix.app.openURLInDefaultBrowser('https://phcode.io')\">Baixar</button></div>",
+    "FOR_VERSIONS": "<=5.2.0",
+    "PLATFORM": "win"
+  },
   "DESKTOP_APP_BANNER": {
     "DANGER_SHOW_ON_EVERY_BOOT" : false,
     "HTML_CONTENT": "<div><b>Apresentamos</b> os <b>aplicativos de desktop</b> Phoenix Code para Windows, Mac e Linux. <a class='notification_ack' href='https://phcode.io' _target='_blank'> Clique aqui para obtê-lo agora!</a></div>",

--- a/docs/appNotifications/prod/root/banner.json
+++ b/docs/appNotifications/prod/root/banner.json
@@ -1,4 +1,10 @@
 {
+  "CRITICAL_WINDOWS_UPDATE_5_2_0": {
+    "DANGER_SHOW_ON_EVERY_BOOT": true,
+    "HTML_CONTENT": "<div style='display:flex;align-items:center;gap:10px;'><div><div style='font-weight:600;'>Critical Update Required</div><div style='opacity:0.85;font-size:0.9em;'>This version of Phoenix Code for Windows has a critical stability issue. Please download and install the latest version from phcode.io.</div></div><button class='btn primary' onclick=\"Phoenix.app.openURLInDefaultBrowser('https://phcode.io')\">Download</button></div>",
+    "FOR_VERSIONS": "<=5.2.0",
+    "PLATFORM": "win"
+  },
   "DESKTOP_APP_BANNER": {
     "DANGER_SHOW_ON_EVERY_BOOT" : false,
     "HTML_CONTENT": "<div><b>Introducing</b> Phoenix Code <b>Desktop Apps</b> for Windows, Mac & Linux. <a class='notification_ack' href='https://phcode.io' _target='_blank'> Click here to get it now!</a></div>",


### PR DESCRIPTION
## What

Adds a `CRITICAL_WINDOWS_UPDATE_5_2_0` banner notification to `docs/appNotifications/prod`, shown only on Windows desktop installs at version `<=5.2.0`, directing users to phcode.io to download a current build.

## Banner

> **Critical Update Required**
> This version of Phoenix Code for Windows has a critical stability issue. Please download and install the latest version from phcode.io.  `[ Download ]`

The Download button calls `Phoenix.app.openURLInDefaultBrowser('https://phcode.io')`, matching the existing lifetime-deal banner.

## Config

| Field | Value |
|---|---|
| `PLATFORM` | `win` — Windows desktop only |
| `FOR_VERSIONS` | `<=5.2.0` |
| `DANGER_SHOW_ON_EVERY_BOOT` | `true` |
| `USER_TYPE` | not set — all users |

No `notification_ack` class, so clicking Download does not suppress the banner. It reappears every launch until the user actually updates past 5.2.0.

## Translations

de, fr, it, ja, ko and pt-BR are hand-written in this PR rather than left to the auto-translation action, so the banner ships fully localized without waiting for a follow-up bot PR. All 7 files validated as parseable JSON.

## Deploying

Per `docs/appNotifications/readme.md`, merging to `main` is not sufficient — `main` must then be merged into the `update-notifications` branch to push this to the installed base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ifem1U6QZyHLTLs8EVitr